### PR TITLE
pkp/pkp-lib#3448 Localize submission titles against submission locale.

### DIFF
--- a/src/components/ListPanel/submissions/SubmissionsListItem.vue
+++ b/src/components/ListPanel/submissions/SubmissionsListItem.vue
@@ -11,7 +11,7 @@
 						{{ item.authorString }}
 					</div>
 					<div class="pkpListPanelItem--submission__title">
-						{{ localize(item.fullTitle) }}
+						{{ localizeSubmission(item.fullTitle, item.locale) }}
 					</div>
 					<div v-if="notice" class="pkpListPanelItem--submission__activity">
 						<icon icon="exclamation-triangle" :inline="true" />
@@ -157,10 +157,12 @@ import ListItem from '@/components/List/ListItem.vue';
 import Badge from '@/components/Badge/Badge.vue';
 import PkpButton from '@/components/Button/Button.vue';
 import Icon from '@/components/Icon/Icon.vue';
+import LocalizeSubmission from '@/mixins/localizeSubmission.js';
 
 export default {
 	extends: ListPanelItem,
 	name: 'SubmissionsListItem',
+	mixins: [LocalizeSubmission],
 	components: {
 		List,
 		ListItem,

--- a/src/mixins/global.js
+++ b/src/mixins/global.js
@@ -49,7 +49,10 @@ export default {
 		 *
 		 * It will search for the current locale value. If there's no value for the
 		 * current locale, it will revert to the primary locale. If there's still
-		 * no match, it will return an empty string.
+		 * no match, it will return the first available value or an empty string.
+		 *
+		 * This method mimics the DataObject::getLocalizedData() method from the
+		 * PHP backend.
 		 *
 		 * This can be used in templates like this:
 		 *
@@ -60,7 +63,7 @@ export default {
 		 * {{ localize(fullTitle, 'fr_CA') }}
 		 *
 		 * @param object localizedString Key/value hash storing one string per locale
-		 * @param string locale Optional. The locale to search for.
+		 * @param string requestedLocale Optional. Request a specific locale
 		 * @return string
 		 */
 		localize: function (localizedString, requestedLocale) {
@@ -68,11 +71,18 @@ export default {
 				return '';
 			}	else if (requestedLocale !== undefined) {
 				return localizedString.hasOwnProperty(requestedLocale) ? localizedString[requestedLocale] : '';
-			} else if (localizedString.hasOwnProperty($.pkp.app.currentLocale)) {
+			} else if (localizedString.hasOwnProperty($.pkp.app.currentLocale) && localizedString[$.pkp.app.currentLocale]) {
 				return localizedString[$.pkp.app.currentLocale];
-			} else if (localizedString.hasOwnProperty($.pkp.app.primaryLocale)) {
+			} else if (localizedString.hasOwnProperty($.pkp.app.primaryLocale) && localizedString[$.pkp.app.primaryLocale]) {
 				return localizedString[$.pkp.app.primaryLocale];
 			}
+
+			for (var key in localizedString) {
+				if (localizedString[key]) {
+					return localizedString[key];
+				}
+			}
+
 			return '';
 		},
 

--- a/src/mixins/localizeSubmission.js
+++ b/src/mixins/localizeSubmission.js
@@ -1,0 +1,39 @@
+/**
+ * Mixin for localizing submission data, which accounts for submission locale.
+ *
+ * @see https://vuejs.org/v2/guide/mixins.html
+ */
+export default {
+
+	methods: {
+		/**
+		 * Get a submission's locale-specific string from a locale object.
+		 *
+		 * This method mimics the global localize mixin, but falls back to the
+		 * submission locale before falling back to the journal's primary locale.
+		 *
+		 * @param object localizedString Key/value hash storing one string per locale
+		 * @param string submissionLocale The submission's locale
+		 * @return string
+		 */
+		localizeSubmission: function (localizedString, submissionLocale) {
+			if (localizedString === null) {
+				return '';
+			} else if (localizedString.hasOwnProperty($.pkp.app.currentLocale) && localizedString[$.pkp.app.currentLocale]) {
+				return localizedString[$.pkp.app.currentLocale];
+			}	else if (localizedString.hasOwnProperty(submissionLocale) && localizedString[submissionLocale]) {
+				return localizedString[submissionLocale];
+			} else if (localizedString.hasOwnProperty($.pkp.app.primaryLocale) && localizedString[$.pkp.app.primaryLocale]) {
+				return localizedString[$.pkp.app.primaryLocale];
+			}
+
+			for (var key in localizedString) {
+				if (localizedString[key]) {
+					return localizedString[key];
+				}
+			}
+
+			return '';
+		},
+	},
+};


### PR DESCRIPTION
This commit introduces a localizeSubmission mixin which will change the
localization fallback order to include the submission locale. It also
fixes some issues with the existing localize mixin to make it behave
like the PHP getLocalizedData methods. Finally, it fixes an error where
empty locale strings were likely to be printed unnecessarily.