### PR TITLE
Add missing semicolon

### DIFF
--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -2,7 +2,7 @@ require('./check-versions')();
 
 var config = require('../config');
 if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = JSON.parse(config.dev.env.NODE_ENV)
+  process.env.NODE_ENV = JSON.parse(config.dev.env.NODE_ENV);
 }
 
 var opn = require('opn');


### PR DESCRIPTION
This fixes a warning from LGTM:

    Avoid automated semicolon insertion (96% of all statements
    in the enclosing script have an explicit semicolon).

Signed-off-by: Stefan Weil <sw@weilnetz.de>