### PR TITLE
Revert formatting

### DIFF
--- a/src/docs/pages/accessibility.md
+++ b/src/docs/pages/accessibility.md
@@ -57,7 +57,7 @@ You should _not_ use `display: hidden`, because screen readers will ignore the t
 A search field often uses an icon to indicate it's purpose. The `placeholder` attribute can not be read by all screen readers, so a label is provided and then hidden from sighted users.
 
 ### Icon-only buttons
-```
+
 <div class="pkpul-element">
 	<div class="pkpul-element__preview">
 		<div class="pkpul-accessible-icon-only-button">
@@ -70,7 +70,7 @@ A search field often uses an icon to indicate it's purpose. The `placeholder` at
 			</p>
 		</div>
 	</div>
-
+```
 <div class="pkpul-accessible-icon-only-button">
 	<p>
 		My example submission
@@ -81,5 +81,6 @@ A search field often uses an icon to indicate it's purpose. The `placeholder` at
 	</p>
 </div>
 ```
+</div>
 
 In a few cases, an icon may not need a text label for sighted users to understand it's purpose. A hidden text label should still be provided for those using screen readers.

--- a/src/docs/pages/accessibility.md
+++ b/src/docs/pages/accessibility.md
@@ -32,7 +32,7 @@ When a component uses icons or a visual layout to indicate the meaning of someth
 You should _not_ use `display: hidden`, because screen readers will ignore the text.
 
 ### Hidden search label
-```
+
 <div class="pkpul-element">
 	<div class="pkpul-element__preview">
 		<div class="pkpul-accessible-search">
@@ -43,7 +43,7 @@ You should _not_ use `display: hidden`, because screen readers will ignore the t
 			</label>
 		</div>
 	</div>
-</div>
+```
 <div class="pkpul-accessible-search">
 	<icon icon="search" />
 	<input id="searchInput" placeholder="Search submissions">
@@ -52,6 +52,8 @@ You should _not_ use `display: hidden`, because screen readers will ignore the t
 	</label>
 </div>
 ```
+</div>
+
 A search field often uses an icon to indicate it's purpose. The `placeholder` attribute can not be read by all screen readers, so a label is provided and then hidden from sighted users.
 
 ### Icon-only buttons

--- a/src/docs/pages/elements.md
+++ b/src/docs/pages/elements.md
@@ -3,13 +3,14 @@
 Elements are composed of HTML and can be written into any component.
 
 ## Spinner
-```
+
 <div class="pkpul-element">
 	<div class="pkpul-element__preview">
 		<span class="pkpSpinner" aria-hidden="true"></span>
 	</div>
-	<span class="pkpSpinner" aria-hidden="true"></span>
-</div>
 ```
+	<span class="pkpSpinner" aria-hidden="true"></span>
+```
+</div>
 
 Use the spinner to indicate when a request is pending, a component is loading or the user must wait for some activity to complete.


### PR DESCRIPTION
@asmecher A heads up on this revert in case it happens again. It looks funny, but the mix of rendered HTML and code-example HTML here is correct. It displays something like this:

![selection_034](https://user-images.githubusercontent.com/2306629/48423765-285ba380-e759-11e8-9d1a-42637ced904a.png)
