### PR TITLE
pkp/pkp-lib#4890 Restore tinymce features to FieldRichTextarea

### DIFF
--- a/src/components/Container/WorkflowContainerOJS.vue
+++ b/src/components/Container/WorkflowContainerOJS.vue
@@ -6,44 +6,61 @@ export default {
 	extends: WorkflowContainer,
 	data() {
 		return {
-			issueApiUrl: ''
+			issueApiUrl: '',
+			sectionWordLimits: {}
 		};
 	},
 	watch: {
 		workingPublication(newVal, oldVal) {
+			// Update the abstract word count when the section changes
+			if (
+				newVal.sectionId !== oldVal.sectionId &&
+				this.components[pkp.const.FORM_TITLE_ABSTRACT]
+			) {
+				const wordLimit = this.sectionWordLimits[newVal.sectionId] || 0;
+				let form = {...this.components[pkp.const.FORM_TITLE_ABSTRACT]};
+				form.fields = form.fields.map(field => {
+					if (field.name === 'abstract') {
+						field.wordLimit = wordLimit;
+					}
+					return field;
+				});
+				this.components[pkp.const.FORM_TITLE_ABSTRACT] = {};
+				this.components[pkp.const.FORM_TITLE_ABSTRACT] = form;
+			}
+
 			// Update the issue volume and number used in the DOI
 			// field when the issue changes
-			if (newVal.issueId === oldVal.issueId) {
-				return;
-			}
-			var self = this;
-			$.ajax({
-				url: this.issueApiUrl.replace('__issueId__', newVal.issueId),
-				type: 'GET',
-				error(r) {
-					self.ajaxErrorCallback(r);
-				},
-				success(r) {
-					self.publicationFormIds.forEach(formId => {
-						if (formId !== pkp.const.FORM_PUBLICATION_IDENTIFIERS) {
-							return;
-						}
-						let form = {...self.components[formId]};
-						form.fields = form.fields.map(field => {
-							if (field.name === 'pub-id::doi') {
-								field.issueNumber = r.number || '';
-								field.issueVolume = r.volume || '';
-								if (!self.workingPublication.datePublished) {
-									field.year = r.year || '';
-								}
+			if (newVal.issueId !== oldVal.issueId) {
+				var self = this;
+				$.ajax({
+					url: this.issueApiUrl.replace('__issueId__', newVal.issueId),
+					type: 'GET',
+					error(r) {
+						self.ajaxErrorCallback(r);
+					},
+					success(r) {
+						self.publicationFormIds.forEach(formId => {
+							if (formId !== pkp.const.FORM_PUBLICATION_IDENTIFIERS) {
+								return;
 							}
-							return field;
+							let form = {...self.components[formId]};
+							form.fields = form.fields.map(field => {
+								if (field.name === 'pub-id::doi') {
+									field.issueNumber = r.number || '';
+									field.issueVolume = r.volume || '';
+									if (!self.workingPublication.datePublished) {
+										field.year = r.year || '';
+									}
+								}
+								return field;
+							});
+							self.components[formId] = {};
+							self.components[formId] = form;
 						});
-						self.components[formId] = {};
-						self.components[formId] = form;
-					});
-				}
-			});
+					}
+				});
+			}
 		}
 	}
 };

--- a/src/components/Form/fields/FieldRichTextarea.vue
+++ b/src/components/Form/fields/FieldRichTextarea.vue
@@ -45,7 +45,8 @@
 			<div class="pkpFormField--richTextarea__toolbar" :id="toolbarId"></div>
 			<editor
 				class="pkpFormField__input pkpFormField--richTextarea__input"
-				v-model="currentValue"
+				v-model="editorValue"
+				ref="editor"
 				:id="controlId"
 				:toolbar="toolbar"
 				:plugins="plugins"
@@ -53,13 +54,26 @@
 				@onFocus="focus"
 				@onBlur="blur"
 			/>
-			<multilingual-progress
-				v-if="isMultilingual && locales.length > 1"
-				:id="multilingualProgressId"
-				:count="multilingualFieldsCompleted"
-				:total="locales.length"
-				:i18n="i18n"
-			/>
+			<div
+				v-if="(isMultilingual && locales.length > 1) || wordLimit"
+				class="pkpFormField--richTextarea__controlFooter"
+			>
+				<multilingual-progress
+					v-if="isMultilingual && locales.length > 1"
+					:id="multilingualProgressId"
+					:count="multilingualFieldsCompleted"
+					:total="locales.length"
+					:i18n="i18n"
+				/>
+				<div v-if="wordLimit" class="pkpFormField--richTextarea__wordLimit">
+					<icon
+						v-if="wordCount > wordLimit"
+						icon="exclamation-triangle"
+						:inline="true"
+					/>
+					{{ __('wordCount', {count: wordCount, limit: wordLimit}) }}
+				</div>
+			</div>
 		</div>
 		<field-error
 			v-if="errors.length"
@@ -72,32 +86,17 @@
 <script>
 import FieldBase from './FieldBase.vue';
 import Editor from '@tinymce/tinymce-vue';
+import Icon from '@/components/Icon/Icon.vue';
+import debounce from 'debounce';
 
 export default {
 	name: 'FieldRichTextarea',
 	extends: FieldBase,
 	components: {
-		Editor
+		Editor,
+		Icon
 	},
 	props: {
-		size: {
-			type: String,
-			default: 'default'
-		},
-		// @see https://www.tinymce.com/docs/configure/editor-appearance/#toolbar
-		toolbar: {
-			type: String,
-			default() {
-				return 'bold italic superscript subscript | link';
-			}
-		},
-		// @see https://www.tiny.cloud/docs/configure/integration-and-setup/#plugins
-		plugins: {
-			type: String,
-			default() {
-				return 'paste,link';
-			}
-		},
 		// @see https://www.tiny.cloud/docs/configure/integration-and-setup/
 		init: {
 			type: Object,
@@ -108,11 +107,51 @@ export default {
 					entity_encoding: 'raw'
 				};
 			}
+		},
+		// @see https://www.tiny.cloud/docs/configure/integration-and-setup/#plugins
+		plugins: {
+			type: String,
+			required: true
+		},
+		preparedContent: {
+			type: Object,
+			default() {
+				return {};
+			}
+		},
+		renderPreparedContent: {
+			type: Boolean,
+			default() {
+				return false;
+			}
+		},
+		size: {
+			type: String,
+			default: 'default'
+		},
+		// @see https://www.tinymce.com/docs/configure/editor-appearance/#toolbar
+		toolbar: {
+			type: String,
+			required: true
+		},
+		uploadUrl: {
+			type: String,
+			default() {
+				return '';
+			}
+		},
+		wordLimit: {
+			type: Number,
+			default() {
+				return 0;
+			}
 		}
 	},
 	data() {
 		return {
-			isFocused: false
+			editorValue: '',
+			isFocused: false,
+			wordCount: 0
 		};
 	},
 	computed: {
@@ -132,8 +171,34 @@ export default {
 		 * @return {Object}
 		 */
 		compiledInit() {
+			var self = this;
 			return {
 				inline: true,
+				paste_data_images: true,
+				relative_urls: false,
+				remove_script_host: false,
+				convert_urls: true,
+				// See: https://www.tiny.cloud/docs/general-configuration-guide/upload-images/#rollingyourimagehandler
+				images_upload_handler(blobInfo, success, failure) {
+					const data = new FormData();
+					data.append('file', blobInfo.blob(), blobInfo.filename());
+					$.ajax({
+						method: 'POST',
+						url: self.uploadUrl,
+						data: data,
+						processData: false,
+						contentType: false,
+						headers: {
+							'X-Csrf-Token': $.pkp.currentUser.csrfToken
+						},
+						success(r) {
+							success(r.url);
+						},
+						error(r) {
+							failure(r.responseJSON.errorMessage);
+						}
+					});
+				},
 				fixed_toolbar_container: '#' + this.toolbarId,
 				init_instance_callback: editor => {
 					// The inline toolbar only appears after the field has been focused.
@@ -142,11 +207,72 @@ export default {
 					editor.fire('focus');
 					editor.fire('blur');
 				},
+				setup(editor) {
+					if (Object.keys(self.preparedContent).length) {
+						editor.addButton('pkpPreparedContent', {
+							icon: 'nonbreaking',
+							type: 'panelbutton',
+							panel: {
+								html() {
+									var markup =
+										'<ul class="pkpFormField--richTextarea__tinymcePanel">';
+									Object.keys(self.preparedContent).forEach(
+										key =>
+											(markup += `<li>
+													<button data-symbolic="${key}">
+														${self.preparedContent[key]}
+													</button>
+												</li>`)
+									);
+									return markup + '</ul>';
+								},
+								onclick(e) {
+									if (e.target.tagName !== 'BUTTON') {
+										return;
+									}
+									const key = e.target.dataset.symbolic;
+									if (self.renderPreparedContent) {
+										editor.insertContent(self.preparedContent[key]);
+									} else {
+										editor.insertContent(
+											self.getPlaceholder(key, self.preparedContent[key])
+										);
+									}
+									this.hide();
+								}
+							}
+						});
+						editor.settings.toolbar += ' | pkpPreparedContent';
+					}
+				},
 				...this.init
 			};
 		}
 	},
 	methods: {
+		/**
+		 * When the input control loses focus
+		 */
+		blur() {
+			this.isFocused = false;
+
+			if (!this.renderPreparedContent) {
+				const keys = Object.keys(this.preparedContent);
+
+				// Find and replace any placeholders
+				if (keys.length) {
+					const value = document.createElement('div');
+					value.innerHTML = this.editorValue;
+					value.querySelectorAll('.pkpTag[data-symbolic]').forEach(node => {
+						node.replaceWith('{$' + node.dataset.symbolic + '}');
+					});
+					this.currentValue = value.innerHTML;
+				} else {
+					this.currentValue = this.editorValue;
+				}
+			}
+		},
+
 		/**
 		 * When the input control gets focus
 		 */
@@ -155,11 +281,85 @@ export default {
 		},
 
 		/**
-		 * When the input control loses focus
+		 * Get a placeholder for prepared content
+		 *
+		 * @param string key The property name
+		 * @param string value The rendered content value
+		 * @return string
 		 */
-		blur() {
-			this.isFocused = false;
+		getPlaceholder(key, value) {
+			return `<span class="pkpTag mceNonEditable" data-symbolic="${key}">${value}</span>`;
+		},
+
+		/**
+		 * Set the editor value to the currentValue and
+		 * process any prepared content
+		 */
+		setEditorValue() {
+			this.editorValue = this.currentValue;
+
+			const keys = Object.keys(this.preparedContent);
+			if (keys.length) {
+				let value = this.editorValue;
+				// Replace {$tags} in the body text with their values
+				if (this.renderPreparedContent) {
+					keys.forEach(key => {
+						value = value.replace(
+							new RegExp('\\{\\$' + key + '\\}', 'g'),
+							this.preparedContent[key]
+						);
+					});
+
+					// Or replace {$tags} in the body text with placeholders
+				} else {
+					keys.forEach(key => {
+						value = value.replace(
+							new RegExp('\\{\\$' + key + '\\}', 'g'),
+							this.getPlaceholder(key, this.preparedContent[key])
+						);
+					});
+				}
+				this.editorValue = value;
+			}
+		},
+
+		/**
+		 * Update the word count based on the current value
+		 */
+		setWordCount: debounce(function() {
+			if (!this.wordLimit || !this.editorValue || !this.$refs.editor) {
+				this.wordCount = 0;
+				return;
+			}
+			const words = this.$refs.editor.editor
+				.getContent({format: 'text'})
+				.match(/\S+/g);
+			if (words !== null) {
+				this.wordCount = words.length;
+				return;
+			}
+			this.wordCount = 0;
+		}, 250)
+	},
+	watch: {
+		editorValue(newVal, oldVal) {
+			if (newVal === oldVal) {
+				return;
+			}
+			this.setWordCount();
+		},
+		currentValue(newVal, oldVal) {
+			if (newVal === oldVal) {
+				return;
+			}
+			this.setEditorValue();
 		}
+	},
+	created() {
+		this.setEditorValue();
+	},
+	mounted() {
+		this.setWordCount();
 	}
 };
 </script>
@@ -215,6 +415,11 @@ export default {
 		font-weight: @bold;
 		text-transform: uppercase;
 		color: @text-light;
+
+		&[contentEditable='false'][data-mce-selected] {
+			outline: 1px solid @primary;
+			border-radius: 2px;
+		}
 	}
 }
 
@@ -222,10 +427,17 @@ export default {
 	height: 35em;
 }
 
-.pkpFormField--richTextarea .multilingualProgress {
+.pkpFormField--richTextarea__controlFooter {
+	display: flex;
+	align-items: center;
 	padding: @half @base;
-	display: block;
 	border-top: @bg-border;
+	font-size: @font-tiny;
+	line-height: @line-sml;
+}
+
+.pkpFormField--richTextarea__wordLimit {
+	margin-left: auto;
 }
 
 // Override tinymce styles
@@ -285,6 +497,30 @@ export default {
 	.mce-btn.mce-active:focus,
 	.mce-btn.mce-active:active {
 		background-color: @primary;
+	}
+}
+
+.mce-popover {
+	.pkpFormField--richTextarea__tinymcePanel {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+
+		li:not(:last-child) {
+			border-bottom: @bg-border;
+		}
+
+		button {
+			padding: 0.5em 0.75em 0.5em 0.5em;
+			border-left: 0.25em solid transparent;
+			font-size: @font-tiny;
+			line-height: @line-tiny;
+
+			&:hover,
+			&:focus {
+				border-left-color: @primary;
+			}
+		}
 	}
 }
 </style>

--- a/src/docs/components/Form/fields/FieldRichTextarea/ComponentFieldRichTextarea.vue
+++ b/src/docs/components/Form/fields/FieldRichTextarea/ComponentFieldRichTextarea.vue
@@ -2,12 +2,20 @@
 import Component from '@/docs/Component.vue';
 import ExampleFieldRichTextarea from './ExampleFieldRichTextarea.vue';
 import ExampleLarge from './ExampleLarge.vue';
+import ExampleMediumToolbar from './ExampleMediumToolbar.vue';
+import ExampleHeavyToolbar from './ExampleHeavyToolbar.vue';
+import ExamplePreparedContent from './ExamplePreparedContent.vue';
+import ExampleWordLimit from './ExampleWordLimit.vue';
 
 export default {
 	extends: Component,
 	components: {
 		ExampleFieldRichTextarea,
-		ExampleLarge
+		ExampleLarge,
+		ExampleMediumToolbar,
+		ExampleHeavyToolbar,
+		ExamplePreparedContent,
+		ExampleWordLimit
 	},
 	data() {
 		return {
@@ -15,7 +23,11 @@ export default {
 			parentRoute: 'Form/fields',
 			examples: {
 				ExampleFieldRichTextarea: 'Base',
-				ExampleLarge: 'Large'
+				ExampleLarge: 'Large',
+				ExampleMediumToolbar: 'Medium Toolbar',
+				ExampleHeavyToolbar: 'Heavy Toolbar',
+				ExamplePreparedContent: 'PreparedContent',
+				ExampleWordLimit: 'Word Limit'
 			}
 		};
 	}

--- a/src/docs/components/Form/fields/FieldRichTextarea/ExampleFieldRichTextarea.vue
+++ b/src/docs/components/Form/fields/FieldRichTextarea/ExampleFieldRichTextarea.vue
@@ -5,8 +5,8 @@ import config from './config';
 
 config.props = {
 	...config.props,
-	toolbar: FieldRichTextarea.props.toolbar.default(),
-	plugins: FieldRichTextarea.props.plugins.default(),
+	toolbar: 'bold italic superscript subscript | link',
+	plugins: 'paste,link',
 	init: FieldRichTextarea.props.init.default()
 };
 

--- a/src/docs/components/Form/fields/FieldRichTextarea/ExampleHeavyToolbar.vue
+++ b/src/docs/components/Form/fields/FieldRichTextarea/ExampleHeavyToolbar.vue
@@ -1,0 +1,21 @@
+<script>
+import ExampleFieldRichTextarea from './ExampleFieldRichTextarea.vue';
+
+export default {
+	extends: ExampleFieldRichTextarea,
+	data() {
+		const data = ExampleFieldRichTextarea.data();
+		return {
+			...data,
+			props: {
+				...data.props,
+				plugins: 'paste,link,lists,image,code',
+				size: 'large',
+				label: 'Editorial Team',
+				toolbar:
+					'bold italic superscript subscript | link | blockquote bullist numlist | image | code'
+			}
+		};
+	}
+};
+</script>

--- a/src/docs/components/Form/fields/FieldRichTextarea/ExampleMediumToolbar.vue
+++ b/src/docs/components/Form/fields/FieldRichTextarea/ExampleMediumToolbar.vue
@@ -1,0 +1,19 @@
+<script>
+import ExampleFieldRichTextarea from './ExampleFieldRichTextarea.vue';
+
+export default {
+	extends: ExampleFieldRichTextarea,
+	data() {
+		const data = ExampleFieldRichTextarea.data();
+		return {
+			...data,
+			props: {
+				...data.props,
+				toolbar:
+					'bold italic superscript subscript | link | blockquote bullist numlist',
+				plugins: data.props.plugins + ',lists'
+			}
+		};
+	}
+};
+</script>

--- a/src/docs/components/Form/fields/FieldRichTextarea/ExamplePreparedContent.vue
+++ b/src/docs/components/Form/fields/FieldRichTextarea/ExamplePreparedContent.vue
@@ -1,0 +1,41 @@
+<script>
+import ExampleFieldBase from '../FieldBase/ExampleFieldBase.vue';
+import FieldRichTextarea from '@/components/Form/fields/FieldRichTextarea.vue';
+import config from './config';
+
+export default {
+	extends: ExampleFieldBase,
+	components: {
+		FieldRichTextarea
+	},
+	data() {
+		return {
+			...config,
+			props: {
+				...config.props,
+				label: 'Accepted Email Template',
+				toolbar: 'bold italic superscript subscript | link',
+				plugins: 'paste,link,noneditable',
+				init: FieldRichTextarea.props.init.default(),
+				preparedContent: {
+					contextName: 'Journal Name',
+					editorName: 'Editor Name',
+					editorRole: 'Editor Role',
+					dueDate: 'Due Date',
+					recipientName: 'Recipient Name',
+					submissionTitle: 'Submission Title'
+				},
+				size: 'large',
+				value: `<p>Hi {$recipientName},</p>
+					<p>We are delighted to inform you that your submission, "{$submissionTitle}", has been accepted to the {$contextName}.</p>
+					<p>At this time, we ask you to please let us know if there are any further adjustments you would like to make before our copyeditor begins working on it.</p>
+					<p>Please let us know by {$dueDate}.</p>
+					<p>Sincerely,<br>
+					{$editorName}, {$editorRole}<br>
+					{$contextName}</p>`
+			},
+			component: 'field-rich-textarea'
+		};
+	}
+};
+</script>

--- a/src/docs/components/Form/fields/FieldRichTextarea/ExampleWordLimit.vue
+++ b/src/docs/components/Form/fields/FieldRichTextarea/ExampleWordLimit.vue
@@ -1,0 +1,22 @@
+<script>
+import ExampleFieldRichTextarea from './ExampleFieldRichTextarea.vue';
+
+export default {
+	extends: ExampleFieldRichTextarea,
+	data() {
+		const data = ExampleFieldRichTextarea.data();
+		return {
+			...data,
+			props: {
+				...data.props,
+				label: 'Abstract',
+				wordLimit: 200,
+				i18n: {
+					...data.props.i18n,
+					wordCount: 'Word Count: {$count}/{$limit}'
+				}
+			}
+		};
+	}
+};
+</script>

--- a/src/docs/components/Form/fields/FieldRichTextarea/config.js
+++ b/src/docs/components/Form/fields/FieldRichTextarea/config.js
@@ -1,5 +1,5 @@
 import fieldBase from '../FieldBase/config';
-import fieldRichTextarea from '../../helpers/field-rich-text-citation';
+import fieldRichTextarea from '../../helpers/field-rich-text-description';
 
 export let props = {
 	...fieldBase.props,
@@ -17,6 +17,26 @@ export const propDocs = [
 		description: 'The current value for this field.'
 	},
 	{
+		key: 'init',
+		description:
+			"Provide config properties for TinyMCE's `init` method. Any props you pass will be merged with defaults and can override them. See [TinyMCE documentation](https://www.tiny.cloud/docs/configure/integration-and-setup/)."
+	},
+	{
+		key: 'plugins',
+		description:
+			'Specify plugins the TinyMCE editor should load. See [TinyMCE documentation](https://www.tiny.cloud/docs/configure/integration-and-setup/#plugins).'
+	},
+	{
+		key: 'preparedContent',
+		description:
+			'An optional object containing preset information. When preset information exists, a button will appear in the toolbar. See the [Prepared Content](#/component/Form/fields/FieldRichTextarea/ExamplePreparedContent) example.'
+	},
+	{
+		key: 'renderPreparedContent',
+		description:
+			'When `true` prepared content will be rendered into the template. When `false`, a placeholder will be added. Default is `false`. See the guidance below.'
+	},
+	{
 		key: 'size',
 		description: 'One of `default` or `large`. Default: `default`.'
 	},
@@ -26,14 +46,14 @@ export const propDocs = [
 			'Provide the TinyMCE editor with a custom toolbar. See [TinyMCE documentation](https://www.tinymce.com/docs/configure/editor-appearance/#toolbar).'
 	},
 	{
-		key: 'plugins',
+		key: 'uploadUrl',
 		description:
-			'Specify plugins the TinyMCE editor should load. See [TinyMCE documentation](https://www.tiny.cloud/docs/configure/integration-and-setup/#plugins).'
+			'Optionally provide a URL where images and other files can be uploaded. You still need to add the appropriate buttons and plugins to the `toolbar` and `plugins` props. The most common use is the [image](https://www.tiny.cloud/docs/plugins/image/) plugin.'
 	},
 	{
-		key: 'init',
+		key: 'wordLimit',
 		description:
-			"Provide config properties for TinyMCE's `init` method. Any props you pass will be merged with defaults and can override them. See [TinyMCE documentation](https://www.tiny.cloud/docs/configure/integration-and-setup/)."
+			'Optionally provide a word limit and the editor will display the word count as they type.'
 	}
 ];
 

--- a/src/docs/components/Form/fields/FieldRichTextarea/readme.md
+++ b/src/docs/components/Form/fields/FieldRichTextarea/readme.md
@@ -6,3 +6,45 @@ This component uses the TinyMCE editor. You can pass `toolbar`, `plugins` and `i
 The `size` of the input area will signal to the user how much information they should enter into the field.
 
 The default `size` is best for one to two large paragraphs. If you expect a user to enter more than that, consider using the large size when it fits appropriately within the the form where it appears.
+
+## Image Uploads
+
+The editor will support image uploads, which are placed in the user's directory in the `public` files directory. You must provide the URL to the public files API and add the plugin and toolbar button.
+
+```js
+{
+	...
+	uploadUrl: 'http://journal.com/api/v1/_uploadPublicFile',
+	toolbar: 'bold italic | link | image',
+	plugins: 'paste,link,image'
+}
+```
+
+The image upload will _not_ work in this documented example. It requires a valid upload URL. Use the following to get the `uploadUrl` from within a PKP application:
+
+```php
+$dispatcher = Application::get()
+	->getRequest()
+	->getDispatcher();
+
+$uploadUrl = $dispatcher->url(
+	Application::get()->getRequest(),
+	ROUTE_API,
+	$context->getPath(),
+	'_uploadPublicFile/'
+);
+```
+
+Users must be logged in to upload files.
+
+## Prepared Content
+
+The `preparedContent` prop allows you to pass content to the editor and give the user a point-and-click tool to add that content. This is intended to be used in cases where data can be rendered inside of an email template.
+
+When an editor is assigning a reviewer, the reviewer's name and the due date can be passed to the editor so that the editor can inject this information directly into the email.
+
+In such cases, the `renderPreparedContent` prop should be set to `true`. This will render the reviewer's name and due date directly into the content as the editor is writing the email.
+
+However, when editing email templates, we must preserve the placeholders. In such cases, the `renderPreparedContent` prop should be set to `false`. Instead of adding the reviewer's name, a placeholder will be inserted that says `[Reviewer Name]`.
+
+The [Prepared Content](#/component/Form/fields/FieldRichTextarea/ExamplePreparedContent) example shows the placeholders that are used when `renderPreparedContent` is `false`.

--- a/src/docs/components/Form/helpers/field-rich-text-abstract.js
+++ b/src/docs/components/Form/helpers/field-rich-text-abstract.js
@@ -10,5 +10,6 @@ export default {
 		fr_CA: '',
 		ar_AR: ''
 	},
-	isMultilingual: true
+	isMultilingual: true,
+	wordLimit: 200
 };

--- a/src/docs/components/Form/helpers/field-rich-text-description.js
+++ b/src/docs/components/Form/helpers/field-rich-text-description.js
@@ -1,6 +1,6 @@
 export default {
-	name: 'citation',
+	name: 'description',
 	component: 'field-rich-textarea',
-	label: 'Citation',
+	label: 'Journal Description',
 	value: ''
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,12 @@
 // Tinymce must be loaded before Vue
 import 'tinymce';
 import 'tinymce/themes/modern/theme';
-import 'tinymce/plugins/paste';
+import 'tinymce/plugins/code';
+import 'tinymce/plugins/image';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
-import 'tinymce/plugins/code';
+import 'tinymce/plugins/noneditable';
+import 'tinymce/plugins/paste';
 import 'tinymce/skins/lightgray/skin.min.css';
 import Vue from 'vue';
 import App from './App.vue';


### PR DESCRIPTION
This commit restores some of the custom tinymce features that were
not ported when FieldRichTextarea was created. These include:

- Image uploads, which are now processed by a new API endpoint
- The pkpTags plugin to insert prepared content
- The handling of visual placeholders for the prepared content
- Support for displaying a word count and word limit