### PR TITLE
pkp/pkp-lib#5428 Add FieldText option to require optin before editing

### DIFF
--- a/src/components/Form/fields/FieldText.vue
+++ b/src/components/Form/fields/FieldText.vue
@@ -36,33 +36,42 @@
 			:id="describedByDescriptionId"
 		/>
 		<div class="pkpFormField__control" :class="controlClasses">
-			<input
-				class="pkpFormField__input pkpFormField--text__input"
-				ref="input"
-				v-model="currentValue"
-				:type="inputType"
-				:id="controlId"
-				:name="localizedName"
-				:aria-describedby="describedByIds"
-				:aria-invalid="!!errors.length"
-				:required="isRequired"
-				:style="inputStyles"
-			/>
-			<span
-				v-if="prefix"
-				class="pkpFormField__inputPrefix"
-				v-html="prefix"
-				ref="prefix"
-				:style="prefixStyles"
-				@click="setFocus"
-			/>
-			<multilingual-progress
-				v-if="isMultilingual && locales.length > 1"
-				:id="multilingualProgressId"
-				:count="multilingualFieldsCompleted"
-				:total="locales.length"
-				:i18n="i18n"
-			/>
+			<div class="pkpFormField__control_top">
+				<input
+					class="pkpFormField__input pkpFormField--text__input"
+					ref="input"
+					v-model="currentValue"
+					:type="inputType"
+					:id="controlId"
+					:name="localizedName"
+					:aria-describedby="describedByIds"
+					:aria-invalid="!!errors.length"
+					:disabled="isDisabled"
+					:required="isRequired"
+					:style="inputStyles"
+				/>
+				<span
+					v-if="prefix"
+					class="pkpFormField__inputPrefix"
+					v-html="prefix"
+					ref="prefix"
+					:style="prefixStyles"
+					@click="setFocus"
+				/>
+				<multilingual-progress
+					v-if="isMultilingual && locales.length > 1"
+					:id="multilingualProgressId"
+					:count="multilingualFieldsCompleted"
+					:total="locales.length"
+					:i18n="i18n"
+				/>
+				<pkp-button
+					v-if="optIntoEdit && isDisabled"
+					class="pkpFormField--text__optIntoEdit"
+					:label="optIntoEditLabel"
+					@click="isDisabled = false"
+				/>
+			</div>
 			<field-error
 				v-if="errors.length"
 				:id="describedByErrorId"
@@ -74,12 +83,18 @@
 
 <script>
 import FieldBase from './FieldBase.vue';
+import PkpButton from '@/components/Button/Button.vue';
 
 export default {
 	name: 'FieldText',
 	extends: FieldBase,
+	components: {
+		PkpButton
+	},
 	props: {
 		inputType: String,
+		optIntoEdit: Boolean,
+		optIntoEditLabel: String,
 		size: {
 			default: 'normal',
 			validator: function(value) {
@@ -91,6 +106,7 @@ export default {
 	data() {
 		return {
 			inputStyles: {},
+			isDisabled: false,
 			prefixStyles: {}
 		};
 	},
@@ -176,6 +192,11 @@ export default {
 				}
 			}, 700);
 		});
+
+		// Set the field to disabled if optIntoEdit is passed
+		if (this.optIntoEdit) {
+			this.isDisabled = true;
+		}
 	}
 };
 </script>
@@ -185,6 +206,7 @@ export default {
 
 .pkpFormField--text__input {
 	width: 20em;
+	display: inline-block;
 }
 
 .pkpFormField__control {
@@ -253,6 +275,11 @@ export default {
 	border-color: @primary;
 }
 
+.pkpFormField--text__optIntoEdit {
+	margin-left: 0.25rem;
+	height: 2.5rem; // Match input height
+}
+
 .pkpFormField--sizesmall {
 	.pkpFormField--text__input {
 		width: 10em;
@@ -262,6 +289,12 @@ export default {
 .pkpFormField--sizelarge {
 	.pkpFormField--text__input {
 		width: 100%;
+	}
+
+	.pkpFormField--text__optIntoEdit {
+		margin-left: 0;
+		margin-top: 0.25rem;
+		height: inherit;
 	}
 }
 </style>

--- a/src/docs/components/Form/fields/FieldText/ComponentFieldText.vue
+++ b/src/docs/components/Form/fields/FieldText/ComponentFieldText.vue
@@ -4,6 +4,7 @@ import ExampleFieldText from './ExampleFieldText.vue';
 import ExampleSmall from './ExampleSmall.vue';
 import ExampleLarge from './ExampleLarge.vue';
 import ExamplePrefix from './ExamplePrefix.vue';
+import ExampleOptIntoEdit from './ExampleOptIntoEdit.vue';
 
 export default {
 	extends: Component,
@@ -11,7 +12,8 @@ export default {
 		ExampleFieldText,
 		ExampleSmall,
 		ExampleLarge,
-		ExamplePrefix
+		ExamplePrefix,
+		ExampleOptIntoEdit
 	},
 	data() {
 		return {
@@ -21,7 +23,8 @@ export default {
 				ExampleFieldText: 'Base',
 				ExampleSmall: 'Small',
 				ExampleLarge: 'Large',
-				ExamplePrefix: 'Prefix'
+				ExamplePrefix: 'Prefix',
+				ExampleOptIntoEdit: 'Opt Into Edit'
 			}
 		};
 	}

--- a/src/docs/components/Form/fields/FieldText/ExampleOptIntoEdit.vue
+++ b/src/docs/components/Form/fields/FieldText/ExampleOptIntoEdit.vue
@@ -1,0 +1,19 @@
+<script>
+import ExampleFieldText from './ExampleFieldText.vue';
+
+export default {
+	extends: ExampleFieldText,
+	data() {
+		const data = ExampleFieldText.data();
+		return {
+			...data,
+			props: {
+				...data.props,
+				label: 'Copyright Holder',
+				optIntoEdit: true,
+				optIntoEditLabel: 'Override'
+			}
+		};
+	}
+};
+</script>

--- a/src/docs/components/Form/fields/FieldText/config.js
+++ b/src/docs/components/Form/fields/FieldText/config.js
@@ -22,6 +22,15 @@ export const propDocs = [
 			'The `type` attribute for the `<input>` field. See [available types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). Default: `text`.'
 	},
 	{
+		key: 'optIntoEdit',
+		description:
+			'Disables the field and adds a button that the user must click before they can edit it. Default: `false`.'
+	},
+	{
+		key: 'optIntoEditLabel',
+		description: 'The label for the button added by `optIntoEdit`.'
+	},
+	{
 		key: 'size',
 		description: 'One of `small`, `normal` or `large`. Default: `normal`.'
 	},


### PR DESCRIPTION
If optIntoEdit is passed it disables the field and requires
the user to click a button to enable it.