### PR TITLE
draggable: options props has been deprecated

### DIFF
--- a/src/components/Form/fields/FieldOptions.vue
+++ b/src/components/Form/fields/FieldOptions.vue
@@ -47,7 +47,7 @@
 			<draggable
 				v-model="localizedOptions"
 				@end="updateValueOrder"
-				:options="{disabled: !isOrderable}"
+				disabled="!isOrderable"
 			>
 				<label
 					v-for="option in localizedOptions"


### PR DESCRIPTION
changed according to https://github.com/SortableJS/Vue.Draggable/blob/master/documentation/migrate.md#options-props