### PR TITLE
draggable: options props has been deprecated

### DIFF
--- a/src/components/ListPanel/ListPanel.vue
+++ b/src/components/ListPanel/ListPanel.vue
@@ -70,7 +70,7 @@
 					<draggable
 						v-if="canOrder"
 						v-model="localItems"
-						:options="draggableOptions"
+						v-bind="draggableOptions"
 						@start="drag = true"
 						@end="drag = false"
 					>


### PR DESCRIPTION
changed according to: https://github.com/SortableJS/Vue.Draggable/blob/master/documentation/migrate.md#options-props