### PR TITLE
draggable: options props has been deprecated

### DIFF
--- a/src/components/ListPanel/submissions/CatalogListPanel.vue
+++ b/src/components/ListPanel/submissions/CatalogListPanel.vue
@@ -97,7 +97,7 @@
 
 					<draggable
 						v-model="localItems"
-						:options="draggableOptions"
+						v-bind="draggableOptions"
 						@start="drag = true"
 						@end="drag = false"
 					>


### PR DESCRIPTION
changed according to https://github.com/SortableJS/Vue.Draggable/blob/master/documentation/migrate.md#options-props