### PR TITLE
Fix extra  space bellow submission list when it is empty

### DIFF
--- a/src/components/ListPanel/ListPanel.vue
+++ b/src/components/ListPanel/ListPanel.vue
@@ -780,6 +780,7 @@ export default {
 	left: -9999px;
 	opacity: 0;
 	width: 0;
+	top:-9999px;
 }
 
 .pkpListPanel__content {


### PR DESCRIPTION
This fix removes the extra space bellow empty list submission in the dashboard as reported via forum:
https://forum.pkp.sfu.ca/t/a-problem-after-upgrading-the-ojs-3-2-01/59539/18

