### PR TITLE
Update package @vue/cli-service from 4.5.9 to 4.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "vuedraggable": "^2.24.3"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^4.5.9",
-    "@vue/cli-plugin-eslint": "^4.5.9",
-    "@vue/cli-service": "^4.5.9",
+    "@vue/cli-plugin-babel": "^4.5.15",
+    "@vue/cli-plugin-eslint": "^4.5.15",
+    "@vue/cli-service": "^4.5.15",
     "@vue/eslint-config-prettier": "^4.0.1",
     "babel-eslint": "^10.1.0",
     "element-resize-event": "^3.0.3",


### PR DESCRIPTION
With @vue/cli-service:4.5.9 the command `npm run build` causes:
```
Running webpack build process... 
> OJS3@3.3.0 build
> vue-cli-service build --no-clean

sh: vue-cli-service: command not found
```

```
npm --version
8.1.2
```