### PR TITLE
pkp/pkp-lib#6998 Don't allow mixed type for  `assignedTo` query param

### DIFF
--- a/src/pages/dashboard/mocks/pageInitConfig.js
+++ b/src/pages/dashboard/mocks/pageInitConfig.js
@@ -260,7 +260,7 @@ export default {
 			name: 'Needs editor',
 			count: 1,
 			queryParams: {
-				assignedTo: -1,
+				isUnassigned: true,
 				status: [1],
 			},
 		},


### PR DESCRIPTION
For pkp/pkp-lib#6998