### PR TITLE
add user extended meta data in edit user and edit invitation

### DIFF
--- a/public/globals.js
+++ b/public/globals.js
@@ -894,6 +894,23 @@ window.pkp = {
 		'workflow.submissionNextReviewRoundInFutureStage':
 			'The submission advanced to the next review round, was accepted, and is currently in the {$stage} stage.',
 		'workflow.uploadRevisions': 'Upload revisions',
+		'userInvitation.searchField':
+			'Search for a user by email address, username, or ORCID iD. Enter only one to get started!',
+		'grid.user.enable': 'Enable User',
+		'grid.user.disable': 'Disable User',
+		'grid.user.remove': 'Remove User',
+		'grid.user.logInAs': 'Login As',
+		'grid.user.grid.user.enableReasonDescription':
+			"Once the user is enabled, they will regain access to OJS, and you'll be able to invite them to roles as needed.",
+		'grid.user.grid.user.disableReasonDescription':
+			"Please note that once a user is disabled, you won't be able to add them to any roles until they are enabled again.",
+		'user.disabledModal.description': 'Current Roles : {$roles}',
+		'user.disabledModal.title': 'Disable {$fullName}',
+		'user.enabledModal.title': 'Enable {$fullName}',
+		'user.homePageUrl':'Homepage URL',
+		'user.workingLanguages':'Working Languages',
+		'user.bioStatement':'Bio Statement',
+		'common.viewMoreDetails':'View more details',
 	},
 	tinyMCE: {
 		skinUrl: '/styles/tinymce',

--- a/public/globals.js
+++ b/public/globals.js
@@ -894,20 +894,11 @@ window.pkp = {
 		'workflow.submissionNextReviewRoundInFutureStage':
 			'The submission advanced to the next review round, was accepted, and is currently in the {$stage} stage.',
 		'workflow.uploadRevisions': 'Upload revisions',
-		'userInvitation.searchField':
-			'Search for a user by email address, username, or ORCID iD. Enter only one to get started!',
-		'grid.user.enable': 'Enable User',
-		'grid.user.disable': 'Disable User',
-		'grid.user.remove': 'Remove User',
-		'grid.user.logInAs': 'Login As',
 		'grid.user.grid.user.enableReasonDescription':
 			"Once the user is enabled, they will regain access to OJS, and you'll be able to invite them to roles as needed.",
 		'grid.user.grid.user.disableReasonDescription':
 			"Please note that once a user is disabled, you won't be able to add them to any roles until they are enabled again.",
-		'user.disabledModal.description': 'Current Roles : {$roles}',
-		'user.disabledModal.title': 'Disable {$fullName}',
-		'user.enabledModal.title': 'Enable {$fullName}',
-		'user.homePageUrl':'Homepage URL',
+		'user.url':'Homepage URL',
 		'user.workingLanguages':'Working Languages',
 		'user.bioStatement':'Bio Statement',
 		'common.viewMoreDetails':'View more details',

--- a/src/components/FormDisplay/FormDisplayItemBasic.vue
+++ b/src/components/FormDisplay/FormDisplayItemBasic.vue
@@ -2,7 +2,8 @@
 	<component :is="headingElement" class="text-base-normal text-secondary">
 		{{ heading }}
 	</component>
-	<p class="pt-1 text-lg-normal">{{ value }}</p>
+	<p v-if="!htmlValue" class="pt-1 text-lg-normal">{{ value }}</p>
+	<p v-else v-strip-unsafe-html="htmlValue" class="pt-1 text-lg-normal"></p>
 </template>
 
 <script setup>
@@ -10,5 +11,6 @@ defineProps({
 	headingElement: {required: true, type: String},
 	heading: {type: String, required: true},
 	value: {type: String, required: false, default: '-'},
+	htmlValue: {type: String, required: false, default: null},
 });
 </script>

--- a/src/managers/UserAccessManager/UserAccessManager.vue
+++ b/src/managers/UserAccessManager/UserAccessManager.vue
@@ -46,7 +46,7 @@ import TableBody from '@/components/Table/TableBody.vue';
 import TableRow from '@/components/Table/TableRow.vue';
 import {useUserAccessManagerStore} from './UserAccessManagerStore.js';
 import TablePagination from '@/components/Table/TablePagination.vue';
-import {useTranslation} from '@/composables/useTranslation';
+import {useLocalize} from '@/composables/useLocalize';
 import Search from '@/components/Search/Search.vue';
 import {ref} from 'vue';
 import UserAccessManagerCellStartDate from './UserAccessManagerCellStartDate.vue';
@@ -66,6 +66,6 @@ const Components = {
 };
 
 const store = useUserAccessManagerStore();
-const {t} = useTranslation();
+const {t} = useLocalize();
 const searchPhrase = ref('');
 </script>

--- a/src/managers/UserAccessManager/UserAccessManagerCellActions.vue
+++ b/src/managers/UserAccessManager/UserAccessManagerCellActions.vue
@@ -14,12 +14,12 @@
 import TableCell from '@/components/Table/TableCell.vue';
 import DropdownActions from '@/components/DropdownActions/DropdownActions.vue';
 import {useUserAccessManagerStore} from './UserAccessManagerStore.js';
-import {useTranslation} from '@/composables/useTranslation';
+import {useLocalize} from '@/composables/useLocalize';
 
 defineProps({
 	user: {type: Object, required: true},
 });
 
 const store = useUserAccessManagerStore();
-const {t} = useTranslation();
+const {t} = useLocalize();
 </script>

--- a/src/managers/UserAccessManager/UserAccessManagerStore.js
+++ b/src/managers/UserAccessManager/UserAccessManagerStore.js
@@ -2,7 +2,7 @@ import {defineComponentStore} from '@/utils/defineComponentStore';
 import {useApiUrl} from '@/composables/useApiUrl';
 import {useUrl} from '@/composables/useUrl';
 import {useAnnouncer} from '@/composables/useAnnouncer';
-import {useTranslation} from '@/composables/useTranslation';
+import {useLocalize} from '@/composables/useLocalize';
 import {useFetchPaginated} from '@/composables/useFetchPaginated';
 import {ref, watch} from 'vue';
 import {useUserAccessManagerActions} from './useUserAccessManagerActions';
@@ -10,7 +10,7 @@ import {useUserAccessManagerActions} from './useUserAccessManagerActions';
 export const useUserAccessManagerStore = defineComponentStore(
 	'userAccessManager',
 	() => {
-		const {t} = useTranslation();
+		const {t} = useLocalize();
 		/** Announcer */
 
 		const {announce} = useAnnouncer();

--- a/src/pages/userInvitation/UserInvitationDetailsFormStep.vue
+++ b/src/pages/userInvitation/UserInvitationDetailsFormStep.vue
@@ -61,7 +61,9 @@
 			></FormDisplayItemBasic>
 		</div>
 		<div v-if="store.invitationMode != 'create'">
-			<UserInvitationExtendedMetaData></UserInvitationExtendedMetaData>
+			<ShowMore :label="t('common.viewMoreDetails')">
+				<UserInvitationExtendedMetaData></UserInvitationExtendedMetaData>
+			</ShowMore>
 		</div>
 	</div>
 	<div class="p-8">
@@ -80,6 +82,7 @@ import {useUserInvitationPageStore} from './UserInvitationPageStore';
 import {useForm} from '@/composables/useForm';
 import FormErrorSummary from '@/components/Form/FormErrorSummary.vue';
 import UserInvitationExtendedMetaData from './UserInvitationExtendedMetaData.vue';
+import ShowMore from '@/components/ShowMore/ShowMore.vue';
 
 /**
  * Update the payload by using form values on multilingual or not

--- a/src/pages/userInvitation/UserInvitationDetailsFormStep.vue
+++ b/src/pages/userInvitation/UserInvitationDetailsFormStep.vue
@@ -76,7 +76,7 @@ import {defineProps, computed} from 'vue';
 import FormDisplayItemBasic from '@/components/FormDisplay/FormDisplayItemBasic.vue';
 import Icon from '@/components/Icon/Icon.vue';
 import PkpForm from '@/components/Form/Form.vue';
-import {useTranslation} from '@/composables/useTranslation';
+import {useLocalize} from '@/composables/useLocalize';
 import UserInvitationUserGroupsTable from './UserInvitationUserGroupsTable.vue';
 import {useUserInvitationPageStore} from './UserInvitationPageStore';
 import {useForm} from '@/composables/useForm';
@@ -109,7 +109,7 @@ function updateUserForm(id, form, c, d) {
 	}
 }
 
-const {t} = useTranslation();
+const {t} = useLocalize();
 const store = useUserInvitationPageStore();
 
 const props = defineProps({

--- a/src/pages/userInvitation/UserInvitationDetailsFormStep.vue
+++ b/src/pages/userInvitation/UserInvitationDetailsFormStep.vue
@@ -22,7 +22,7 @@
 		></PkpForm>
 	</div>
 	<div v-if="store.invitationPayload.userId !== null" class="p-8">
-		<div class="flex flex-col gap-y-2">
+		<div class="mb-8 flex flex-col gap-y-2">
 			<FormDisplayItemBasic
 				heading-element="h4"
 				:heading="t('user.email')"
@@ -60,6 +60,9 @@
 				:value="localize(store.invitationPayload.affiliation)"
 			></FormDisplayItemBasic>
 		</div>
+		<div v-if="store.invitationMode != 'create'">
+			<UserInvitationExtendedMetaData></UserInvitationExtendedMetaData>
+		</div>
 	</div>
 	<div class="p-8">
 		<UserInvitationUserGroupsTable :user-groups="userGroups" />
@@ -76,6 +79,7 @@ import UserInvitationUserGroupsTable from './UserInvitationUserGroupsTable.vue';
 import {useUserInvitationPageStore} from './UserInvitationPageStore';
 import {useForm} from '@/composables/useForm';
 import FormErrorSummary from '@/components/Form/FormErrorSummary.vue';
+import UserInvitationExtendedMetaData from './UserInvitationExtendedMetaData.vue';
 
 /**
  * Update the payload by using form values on multilingual or not

--- a/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
+++ b/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
@@ -1,12 +1,5 @@
 <template>
-	<Button
-		is-active
-		:icon="isVisible ? 'Dropup' : 'Dropdown'"
-		@click="isVisible = !isVisible"
-	>
-		{{ t('common.viewMoreDetails') }}
-	</Button>
-	<div v-if="isVisible" class="mt-8 flex flex-col gap-y-2">
+	<div class="mt-8 flex flex-col gap-y-2">
 		<FormDisplayItemBasic
 			heading-element="h4"
 			:heading="t('user.homePageUrl')"
@@ -88,13 +81,10 @@
 </template>
 
 <script setup>
-import Button from '@/components/Button/Button.vue';
 import FormDisplayItemBasic from '@/components/FormDisplay/FormDisplayItemBasic.vue';
 import {useTranslation} from '@/composables/useTranslation';
 import {useUserInvitationPageStore} from './UserInvitationPageStore';
-import {ref} from 'vue';
 
 const {t} = useTranslation();
 const store = useUserInvitationPageStore();
-const isVisible = ref(false);
 </script>

--- a/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
+++ b/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
@@ -2,7 +2,7 @@
 	<div class="mt-8 flex flex-col gap-y-2">
 		<FormDisplayItemBasic
 			heading-element="h4"
-			:heading="t('user.homePageUrl')"
+			:heading="t('user.url')"
 			:value="
 				store.invitationPayload.homePageUrl
 					? store.invitationPayload.homePageUrl

--- a/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
+++ b/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
@@ -44,47 +44,41 @@
 					: '--'
 			"
 		></FormDisplayItemBasic>
-		<h4 class="text-base-normal text-secondary">
-			{{ t('user.bioStatement') }}
-		</h4>
-		<p
-			class="pt-1 text-lg-normal"
-			v-html="
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.bioStatement')"
+			:html-value="
 				localize(store.invitationPayload.biography)
 					? localize(store.invitationPayload.biography)
 					: '--'
 			"
-		></p>
-		<h4 class="text-base-normal text-secondary">
-			{{ t('user.mailingAddress') }}
-		</h4>
-		<p
-			class="pt-1 text-lg-normal"
-			v-html="
+		></FormDisplayItemBasic>
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.mailingAddress')"
+			:html-value="
 				store.invitationPayload.mailingAddress
 					? store.invitationPayload.mailingAddress
 					: '--'
 			"
-		></p>
-		<h4 class="text-base-normal text-secondary">
-			{{ t('user.signature') }}
-		</h4>
-		<p
-			class="pt-1 text-lg-normal"
-			v-html="
+		></FormDisplayItemBasic>
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.signature')"
+			:html-value="
 				localize(store.invitationPayload.signature)
 					? localize(store.invitationPayload.signature)
 					: '--'
 			"
-		></p>
+		></FormDisplayItemBasic>
 	</div>
 </template>
 
 <script setup>
 import FormDisplayItemBasic from '@/components/FormDisplay/FormDisplayItemBasic.vue';
-import {useTranslation} from '@/composables/useTranslation';
+import {useLocalize} from '@/composables/useLocalize';
 import {useUserInvitationPageStore} from './UserInvitationPageStore';
 
-const {t} = useTranslation();
+const {t} = useLocalize();
 const store = useUserInvitationPageStore();
 </script>

--- a/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
+++ b/src/pages/userInvitation/UserInvitationExtendedMetaData.vue
@@ -1,0 +1,100 @@
+<template>
+	<Button
+		is-active
+		:icon="isVisible ? 'Dropup' : 'Dropdown'"
+		@click="isVisible = !isVisible"
+	>
+		{{ t('common.viewMoreDetails') }}
+	</Button>
+	<div v-if="isVisible" class="mt-8 flex flex-col gap-y-2">
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.homePageUrl')"
+			:value="
+				store.invitationPayload.homePageUrl
+					? store.invitationPayload.homePageUrl
+					: '--'
+			"
+		></FormDisplayItemBasic>
+
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.phone')"
+			:value="
+				store.invitationPayload.phone ? store.invitationPayload.phone : '--'
+			"
+		></FormDisplayItemBasic>
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.workingLanguages')"
+			:value="
+				store.invitationPayload.locales ? store.invitationPayload.locales : '--'
+			"
+		></FormDisplayItemBasic>
+
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.interests')"
+			:value="
+				localize(store.invitationPayload.reviewerInterests)
+					? localize(store.invitationPayload.reviewerInterests)
+					: '--'
+			"
+		></FormDisplayItemBasic>
+
+		<FormDisplayItemBasic
+			heading-element="h4"
+			:heading="t('user.affiliation')"
+			:value="
+				localize(store.invitationPayload.affiliation)
+					? localize(store.invitationPayload.affiliation)
+					: '--'
+			"
+		></FormDisplayItemBasic>
+		<h4 class="text-base-normal text-secondary">
+			{{ t('user.bioStatement') }}
+		</h4>
+		<p
+			class="pt-1 text-lg-normal"
+			v-html="
+				localize(store.invitationPayload.biography)
+					? localize(store.invitationPayload.biography)
+					: '--'
+			"
+		></p>
+		<h4 class="text-base-normal text-secondary">
+			{{ t('user.mailingAddress') }}
+		</h4>
+		<p
+			class="pt-1 text-lg-normal"
+			v-html="
+				store.invitationPayload.mailingAddress
+					? store.invitationPayload.mailingAddress
+					: '--'
+			"
+		></p>
+		<h4 class="text-base-normal text-secondary">
+			{{ t('user.signature') }}
+		</h4>
+		<p
+			class="pt-1 text-lg-normal"
+			v-html="
+				localize(store.invitationPayload.signature)
+					? localize(store.invitationPayload.signature)
+					: '--'
+			"
+		></p>
+	</div>
+</template>
+
+<script setup>
+import Button from '@/components/Button/Button.vue';
+import FormDisplayItemBasic from '@/components/FormDisplay/FormDisplayItemBasic.vue';
+import {useTranslation} from '@/composables/useTranslation';
+import {useUserInvitationPageStore} from './UserInvitationPageStore';
+import {ref} from 'vue';
+
+const {t} = useTranslation();
+const store = useUserInvitationPageStore();
+const isVisible = ref(false);
+</script>


### PR DESCRIPTION
#### Adds extended metadata for the Edit invitation page

![metadata](https://github.com/user-attachments/assets/1eb7e530-6234-49a1-90b6-dc0c70a0d59b)
