### PR TITLE
pkp/pkp-lib#11428 Taiwan listed incorrectly in country dropdowns for user registration/management

### DIFF
--- a/src/pages/dashboard/mocks/pageInitConfigEditorial.js
+++ b/src/pages/dashboard/mocks/pageInitConfigEditorial.js
@@ -584,7 +584,7 @@ export default {
 						{value: 'SE', label: 'Sweden'},
 						{value: 'CH', label: 'Switzerland'},
 						{value: 'SY', label: 'Syrian Arab Republic'},
-						{value: 'TW', label: 'Taiwan, Province of China'},
+						{value: 'TW', label: 'Taiwan, Republic of China'},
 						{value: 'TJ', label: 'Tajikistan'},
 						{value: 'TZ', label: 'Tanzania, United Republic of'},
 						{value: 'TH', label: 'Thailand'},

--- a/src/pages/dashboard/mocks/pageInitConfigMySubmissions.js
+++ b/src/pages/dashboard/mocks/pageInitConfigMySubmissions.js
@@ -1235,7 +1235,7 @@ export default {
 						},
 						{
 							value: 'TW',
-							label: 'Taiwan, Province of China',
+							label: 'Taiwan, Republic of China',
 						},
 						{
 							value: 'TJ',

--- a/src/pages/dashboard/mocks/pageInitConfigReviewAssignments.js
+++ b/src/pages/dashboard/mocks/pageInitConfigReviewAssignments.js
@@ -1196,7 +1196,7 @@ export default {
 						},
 						{
 							value: 'TW',
-							label: 'Taiwan, Province of China',
+							label: 'Taiwan, Repubic of China',
 						},
 						{
 							value: 'TJ',


### PR DESCRIPTION
at present Taiwan is listed in dropdowns as "Taiwan, Province of China" as in the PRC/Mainland China. To scholars working in Taiwan and of Taiwanese heritage, this is insulting and offensive. This PR corrects the name of Taiwan to reflect the name used by people on the island of Taiwan.

cf. https://github.com/pkp/pkp-lib/issues/11428