### PR TITLE
Improve form validation accessibility

### DIFF
--- a/src/components/Form/FormErrors.vue
+++ b/src/components/Form/FormErrors.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="pkpFormErrors">
+	<div class="pkpFormErrors" tabindex="-1">
 		<Icon icon="Error" class="h-5 w-5" :inline="true" />
 		{{ message }}
 		<ul class="-screenReader">
@@ -74,6 +74,14 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * Move keyboard focus to the error summary so assistive technology
+		 * users land where the validation feedback is displayed.
+		 */
+		focus() {
+			this.$el.focus();
+		},
+
 		/**
 		 * Emit an event to display the next error in the list
 		 */

--- a/src/components/Form/FormPage.vue
+++ b/src/components/Form/FormPage.vue
@@ -26,6 +26,7 @@
 		>
 			<FormErrors
 				v-if="Object.keys(errors).length && showErrorFooter"
+				ref="formErrors"
 				:errors="errors"
 				:fields="fields"
 				@show-field="showField"
@@ -166,6 +167,22 @@ export default {
 				return '!px-0';
 			}
 			return '';
+		},
+	},
+	watch: {
+		errors(newErrors, oldErrors) {
+			if (
+				!this.isCurrentPage ||
+				!this.showErrorFooter ||
+				!Object.keys(newErrors).length ||
+				Object.keys(oldErrors || {}).length
+			) {
+				return;
+			}
+
+			this.$nextTick(() => {
+				this.$refs.formErrors?.focus();
+			});
 		},
 	},
 	mounted() {

--- a/src/components/Form/fields/FieldArchivingPn.vue
+++ b/src/components/Form/fields/FieldArchivingPn.vue
@@ -53,7 +53,7 @@
 					type="checkbox"
 					:name="name"
 					:aria-describedby="describedByIds"
-					:aria-invalid="!!errors?.length"
+					:aria-invalid="ariaInvalid"
 					:disabled="isSaving || option.disabled"
 				/>
 				{{ option.label }}

--- a/src/components/Form/fields/FieldBase.vue
+++ b/src/components/Form/fields/FieldBase.vue
@@ -182,13 +182,25 @@ export default {
 			if (this.tooltip) {
 				ids.push(this.describedByTooltipId);
 			}
-			if (this.error) {
+			if (this.errors.length) {
 				ids.push(this.describedByErrorId);
 			}
 			if (this.isMultilingual) {
 				ids.push(this.multilingualProgressId);
 			}
 			return ids.length ? ids.join(' ') : undefined;
+		},
+
+		/**
+		 * Mark a field as invalid only when it has validation errors.
+		 *
+		 * Returning undefined removes aria-invalid from valid fields instead of
+		 * rendering aria-invalid="false" or aria-invalid="0".
+		 *
+		 * @return {String|undefined}
+		 */
+		ariaInvalid() {
+			return this.errors.length ? 'true' : undefined;
 		},
 
 		/**

--- a/src/components/Form/fields/FieldDate.vue
+++ b/src/components/Form/fields/FieldDate.vue
@@ -39,7 +39,7 @@
 				type="date"
 				:name="localizedName"
 				:aria-describedby="describedByIds"
-				:aria-invalid="!!errors?.length"
+				:aria-invalid="ariaInvalid"
 				:disabled="disabled"
 				:required="isRequired"
 				:min="computedMin"

--- a/src/components/Form/fields/FieldMetadataSetting.vue
+++ b/src/components/Form/fields/FieldMetadataSetting.vue
@@ -33,7 +33,7 @@
 					type="checkbox"
 					:value="option.value"
 					:aria-describedby="describedByIds"
-					:aria-invalid="!!errors?.length"
+					:aria-invalid="ariaInvalid"
 					:disabled="option.disabled"
 				/>
 				<span
@@ -52,7 +52,7 @@
 						class="pkpFormField--options__input pkpFormField--metadata__submissionInput"
 						type="radio"
 						:value="option.value"
-						:aria-invalid="!!errors?.length"
+						:aria-invalid="ariaInvalid"
 						:disabled="option.disabled"
 					/>
 					<span

--- a/src/components/Form/fields/FieldOptions.vue
+++ b/src/components/Form/fields/FieldOptions.vue
@@ -60,7 +60,7 @@
 							type="checkbox"
 							:name="localizedName"
 							:aria-describedby="describedByIds"
-							:aria-invalid="!!errors?.length"
+							:aria-invalid="ariaInvalid"
 							:disabled="option.disabled"
 						/>
 						<input
@@ -71,7 +71,7 @@
 							type="radio"
 							:name="localizedName"
 							:aria-describedby="describedByIds"
-							:aria-invalid="!!errors?.length"
+							:aria-invalid="ariaInvalid"
 							:disabled="option.disabled"
 						/>
 					</template>

--- a/src/components/Form/fields/FieldPubId.vue
+++ b/src/components/Form/fields/FieldPubId.vue
@@ -30,7 +30,7 @@
 				class="pkpFormField__input pkpFormField--text__input pkpFormField--pubid__input"
 				:name="localizedName"
 				:aria-describedby="describedByIds"
-				:aria-invalid="!!errors?.length"
+				:aria-invalid="ariaInvalid"
 				:disabled="!!pattern"
 				:required="isRequired"
 			/>

--- a/src/components/Form/fields/FieldRadioInput.vue
+++ b/src/components/Form/fields/FieldRadioInput.vue
@@ -51,7 +51,7 @@
 						type="radio"
 						:name="localizedName"
 						:aria-describedby="describedByIds"
-						:aria-invalid="!!errors?.length"
+						:aria-invalid="ariaInvalid"
 						:disabled="option.disabled"
 					/>
 					{{ option.label }}
@@ -63,7 +63,7 @@
 						type="radio"
 						:name="localizedName"
 						:aria-describedby="describedByIds"
-						:aria-invalid="!!errors?.length"
+						:aria-invalid="ariaInvalid"
 						:disabled="option.disabled"
 						@change="selectInput"
 					/>
@@ -74,7 +74,7 @@
 						class="pkpFormField__input pkpFormField--options__input--text"
 						type="text"
 						:aria-describedby="describedByIds"
-						:aria-invalid="!!errors?.length"
+						:aria-invalid="ariaInvalid"
 						:disabled="option.disabled"
 						@focus="selectInput"
 					/>

--- a/src/components/Form/fields/FieldSelect.vue
+++ b/src/components/Form/fields/FieldSelect.vue
@@ -39,7 +39,7 @@
 				:class="inputClasses"
 				:name="localizedName"
 				:aria-describedby="describedByIds"
-				:aria-invalid="!!errors?.length"
+				:aria-invalid="ariaInvalid"
 				:required="isRequired"
 				:disabled="disabled"
 			/>

--- a/src/components/Form/fields/FieldText.vue
+++ b/src/components/Form/fields/FieldText.vue
@@ -39,7 +39,7 @@
 					:type="inputType"
 					:name="localizedName"
 					:aria-describedby="describedByIds"
-					:aria-invalid="!!errors?.length"
+					:aria-invalid="ariaInvalid"
 					:disabled="isDisabled"
 					:required="isRequired"
 					:style="inputStyles"

--- a/src/components/Form/fields/FieldTextarea.vue
+++ b/src/components/Form/fields/FieldTextarea.vue
@@ -36,7 +36,7 @@
 				class="pkpFormField__input pkpFormField--textarea__input"
 				:name="localizedName"
 				:aria-describedby="describedByIds"
-				:aria-invalid="!!errors?.length"
+				:aria-invalid="ariaInvalid"
 				:required="isRequired"
 			></textarea>
 			<MultilingualProgress


### PR DESCRIPTION
## Summary

- Moves focus to the visible form error summary when validation errors first appear on the current form page.
- Removes `aria-invalid` from valid form controls and only renders `aria-invalid="true"` when the field has validation errors.
- Adds the field error message id to `aria-describedby` when errors are present, so the invalid field is programmatically associated with its error text.

## Related issues

Addresses the Vue form stack used by the OJS submission workflow:

- pkp/pkp-lib#12599
- pkp/pkp-lib#12837

## Verification

- `npm test -- --run` — 6 files / 58 tests passed.
- `npx eslint src/components/Form/FormErrors.vue src/components/Form/FormPage.vue src/components/Form/fields/FieldBase.vue src/components/Form/fields/FieldText.vue src/components/Form/fields/FieldTextarea.vue src/components/Form/fields/FieldSelect.vue src/components/Form/fields/FieldDate.vue src/components/Form/fields/FieldOptions.vue src/components/Form/fields/FieldRadioInput.vue src/components/Form/fields/FieldMetadataSetting.vue src/components/Form/fields/FieldPubId.vue src/components/Form/fields/FieldArchivingPn.vue` — 0 errors; existing warnings only.
- `git diff --check` — passed.

Note: `npm run lint` currently exits before linting because the upstream script passes `--ignore-path` while this checkout uses `eslint.config.js`; the targeted ESLint command above avoids that script-level blocker.
