### PR TITLE
pkp/pkp-lib#12932 Trigger search when pressing Enter key

### DIFF
--- a/src/components/Search/Search.vue
+++ b/src/components/Search/Search.vue
@@ -64,9 +64,7 @@ export default {
 	},
 	methods: {
 		/**
-		 * Emit the search phrase once the user presses Enter. Searching as they type moves
-		 * the results out from under a screen reader, so we wait until they say they're done.
-		 * Enter is caught on keydown so it can't submit a form the search sits inside.
+		 * Emit the search phrase on Enter, caught on keydown so it doesn't submit a surrounding form.
 		 *
 		 * @param {Object} el A DOM event
 		 */

--- a/src/components/Search/Search.vue
+++ b/src/components/Search/Search.vue
@@ -8,7 +8,7 @@
 				class="pkpSearch__input"
 				:value="searchPhrase"
 				:placeholder="currentSearchLabel"
-				@keyup="searchPhraseKeyUp"
+				@keydown.enter.prevent="submitSearchPhrase"
 			/>
 			<span class="pkpSearch__icons">
 				<Icon
@@ -31,7 +31,6 @@
 
 <script>
 import {useId} from 'vue';
-import debounce from 'debounce';
 import Icon from '@/components/Icon/Icon.vue';
 export default {
 	components: {Icon},
@@ -52,7 +51,7 @@ export default {
 		},
 	},
 	emits: [
-		/** This event will be emitted when the search phrase changes. The event is debounced so that it will only be emitted when the user stops typing for 250ms. */
+		/** This event will be emitted when the user submits the search phrase with Enter, or clears it. */
 		'search-phrase-changed',
 	],
 	computed: {
@@ -65,15 +64,15 @@ export default {
 	},
 	methods: {
 		/**
-		 * Emit an event when the search phrase changes in response to a keyup
-		 * event in the input field.
+		 * Emit the search phrase once the user presses Enter. Searching as they type moves
+		 * the results out from under a screen reader, so we wait until they say they're done.
+		 * Enter is caught on keydown so it can't submit a form the search sits inside.
 		 *
-		 * @param {Object} data A DOM event (object) or the new search
-		 *  phrase (string)
+		 * @param {Object} el A DOM event
 		 */
-		searchPhraseKeyUp: debounce(function (el) {
+		submitSearchPhrase(el) {
 			this.$emit('search-phrase-changed', el.target.value);
-		}, 250),
+		},
 
 		/**
 		 * Clear the search phrase

--- a/src/managers/CitationManager/CitationManagerSearchField.vue
+++ b/src/managers/CitationManager/CitationManagerSearchField.vue
@@ -1,6 +1,7 @@
 <template>
 	<PkpSearch
 		:search-label="t('submission.citations.structured.search.placeholder')"
+		:search-phrase="citationStore.searchPhrase"
 		@search-phrase-changed="(...args) => citationStore.setSearchPhrase(...args)"
 	/>
 </template>

--- a/src/pages/dashboard/DashboardPage.vue
+++ b/src/pages/dashboard/DashboardPage.vue
@@ -39,7 +39,7 @@
 				<DashboardActiveFilters
 					:active-filters-list="store.filtersFormList"
 					:search-phrase="store.searchPhrase"
-					@clear-filters="store.clearFiltersAndSearch"
+					@clear-filters="store.clearAllFilters"
 					@remove-filter="store.clearFiltersFormField"
 					@clear-search="store.clearSearch"
 				/>

--- a/src/pages/dashboard/components/DashboardActiveFilters.vue
+++ b/src/pages/dashboard/components/DashboardActiveFilters.vue
@@ -39,6 +39,7 @@
 			</button>
 		</div>
 		<PkpButton
+			v-if="activeFiltersList.length"
 			:is-warnable="true"
 			:is-link="true"
 			@click="(...args) => emit('clearFilters', ...args)"

--- a/src/pages/dashboard/dashboardPageStore.js
+++ b/src/pages/dashboard/dashboardPageStore.js
@@ -243,13 +243,6 @@ export const useDashboardPageStore = defineComponentStore(
 			clearFiltersForm();
 		}
 
-		// "Clear Filters" clears the filters and the search text. On the search view nothing is left
-		// afterwards, so the watcher above takes us back to the previous view.
-		function clearFiltersAndSearch() {
-			clearAllFilters();
-			resetSearchPhrase();
-		}
-
 		/**
 		 * Sorting
 		 */
@@ -607,7 +600,7 @@ export const useDashboardPageStore = defineComponentStore(
 			filtersFormQueryParams,
 			updateFiltersForm,
 			clearFiltersForm,
-			clearFiltersAndSearch,
+			clearAllFilters,
 			clearFiltersFormField,
 
 			// Sorting


### PR DESCRIPTION
- This updates all the tables to make the behavior of the search consistent. The search should trigger only when the Enter key is pressed.
- Clear Filters will only clear all the filters, leaving the search text untouched.
- Minor fix to show the x clear search button in Structured References table.