### PR TITLE
pkp/dev-team#285 [ORE Submission] Move the location of the Data Availability block in the form

### DIFF
--- a/src/components/Container/SubmissionWizardPage.vue
+++ b/src/components/Container/SubmissionWizardPage.vue
@@ -125,9 +125,7 @@ export default {
 		/**
 		 * A step's sections grouped for display, keyed by step id
 		 *
-		 * Sections sharing a `group` key render in one panel, using the first
-		 * section's name and description as the heading. Grouped entries reference
-		 * the same section objects, so form updates stay reactive.
+		 * Sections sharing a `group` render in one panel under the group's heading.
 		 */
 		sectionGroupsByStep() {
 			const byStep = {};
@@ -135,12 +133,13 @@ export default {
 				const groups = [];
 				const groupsByKey = {};
 				step.sections.forEach((section) => {
-					const key = section.group || section.id;
+					const group = section.group;
+					const key = group ? group.id : section.id;
 					if (!groupsByKey[key]) {
 						groupsByKey[key] = {
 							id: key,
-							name: section.name,
-							description: section.description,
+							name: group ? group.name : section.name,
+							description: group ? group.description : section.description,
 							sections: [],
 						};
 						groups.push(groupsByKey[key]);

--- a/src/components/Container/SubmissionWizardPage.vue
+++ b/src/components/Container/SubmissionWizardPage.vue
@@ -123,6 +123,36 @@ export default {
 		},
 
 		/**
+		 * A step's sections grouped for display, keyed by step id
+		 *
+		 * Sections sharing a `group` key render in one panel, using the first
+		 * section's name and description as the heading. Grouped entries reference
+		 * the same section objects, so form updates stay reactive.
+		 */
+		sectionGroupsByStep() {
+			const byStep = {};
+			this.steps.forEach((step) => {
+				const groups = [];
+				const groupsByKey = {};
+				step.sections.forEach((section) => {
+					const key = section.group || section.id;
+					if (!groupsByKey[key]) {
+						groupsByKey[key] = {
+							id: key,
+							name: section.name,
+							description: section.description,
+							sections: [],
+						};
+						groups.push(groupsByKey[key]);
+					}
+					groupsByKey[key].sections.push(section);
+				});
+				byStep[step.id] = groups;
+			});
+			return byStep;
+		},
+
+		/**
 		 * Can the user submit?
 		 *
 		 * Check whether the user is connected, all required data is

--- a/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
+++ b/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
@@ -411,6 +411,7 @@ export const PublicationConfig = {
 						publication: selectedPublication,
 						dataCitationEditForm:
 							pageInitConfig.componentForms.dataCitationEditForm,
+						class: 'mb-5',
 					},
 				},
 				{

--- a/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
+++ b/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
@@ -405,21 +405,21 @@ export const PublicationConfig = {
 		}) => {
 			return [
 				{
-					component: 'WorkflowPublicationForm',
-					props: {
-						formName: 'dataAvailability',
-						submission,
-						publication: selectedPublication,
-						canEdit: permissions.canEditPublication,
-					},
-				},
-				{
 					component: 'DataCitationManager',
 					props: {
 						submission,
 						publication: selectedPublication,
 						dataCitationEditForm:
 							pageInitConfig.componentForms.dataCitationEditForm,
+					},
+				},
+				{
+					component: 'WorkflowPublicationForm',
+					props: {
+						formName: 'dataAvailability',
+						submission,
+						publication: selectedPublication,
+						canEdit: permissions.canEditPublication,
 					},
 				},
 			];
@@ -439,15 +439,14 @@ export const PublicationConfig = {
 						submission,
 						publication: selectedPublication,
 						canEdit: permissions.canEditPublication,
-						funderEditForm:
-							pageInitConfig.componentForms.funderEditForm,
+						funderEditForm: pageInitConfig.componentForms.funderEditForm,
 					},
 				},
 			];
 
 			return items;
 		},
-	},	
+	},
 	galleys: {
 		getPrimaryItems: ({submission, selectedPublication, permissions}) => {
 			return [

--- a/src/pages/workflow/composables/useWorkflowConfig/workflowConfigEditorialOJS.js
+++ b/src/pages/workflow/composables/useWorkflowConfig/workflowConfigEditorialOJS.js
@@ -964,17 +964,7 @@ export const PublicationConfig = {
 			pageInitConfig,
 			permissions,
 		}) => {
-			const items = [
-				{
-					component: 'WorkflowPublicationForm',
-					props: {
-						formName: 'dataAvailability',
-						submission,
-						publication: selectedPublication,
-						canEdit: permissions.canEditPublication,
-					},
-				},
-			];
+			const items = [];
 			if (pageInitConfig?.publicationSettings?.supportsDataCitations) {
 				items.push({
 					component: 'DataCitationManager',
@@ -986,6 +976,15 @@ export const PublicationConfig = {
 					},
 				});
 			}
+			items.push({
+				component: 'WorkflowPublicationForm',
+				props: {
+					formName: 'dataAvailability',
+					submission,
+					publication: selectedPublication,
+					canEdit: permissions.canEditPublication,
+				},
+			});
 
 			return items;
 		},
@@ -1004,8 +1003,7 @@ export const PublicationConfig = {
 						submission,
 						publication: selectedPublication,
 						canEdit: permissions.canEditPublication,
-						funderEditForm:
-							pageInitConfig.componentForms.funderEditForm,
+						funderEditForm: pageInitConfig.componentForms.funderEditForm,
 					},
 				},
 			];

--- a/src/pages/workflow/composables/useWorkflowConfig/workflowConfigEditorialOJS.js
+++ b/src/pages/workflow/composables/useWorkflowConfig/workflowConfigEditorialOJS.js
@@ -973,6 +973,7 @@ export const PublicationConfig = {
 						publication: selectedPublication,
 						dataCitationEditForm:
 							pageInitConfig.componentForms.dataCitationEditForm,
+						class: 'mb-5',
 					},
 				});
 			}


### PR DESCRIPTION
Notes:
- Submission wizard has multiple panels which could have multiple forms in it. These panels don't have the group logic since they are not in a single form, so I added a mapper in the `SubmissionWizardPage` where vue logic are handled.
- The `-m-5` class in WorkflowPublicationForm.vue caused rendering issues on the Data Availability form. The section shows directly after the table (without padding) because of this. Easiest fix is to pass class "mb-5" as prop in Data Citation table in the workflow config. I tried several approaches, like passing prop instead to remove the `-m-5` conditionally, but this caused another issue which added a big padding in the form for Data Availability. So I'm left with this one for now, we can go probably back later if this needs to be improved.