### PR TITLE
pkp/pkp-lib#13039 Bug, galleys should be editable by author in OPS if he got the permission

### DIFF
--- a/src/managers/GalleyManager/GalleyManager.stories.js
+++ b/src/managers/GalleyManager/GalleyManager.stories.js
@@ -37,5 +37,6 @@ export const Default = {
 				}),
 			],
 		}),
+		canCurrentUserEditPublication: true,
 	},
 };

--- a/src/managers/GalleyManager/GalleyManager.vue
+++ b/src/managers/GalleyManager/GalleyManager.vue
@@ -67,6 +67,7 @@ const Components = {
 const props = defineProps({
 	publication: {type: Object, required: true},
 	submission: {type: Object, required: true},
+	canCurrentUserEditPublication: {type: Boolean, required: true},
 });
 
 const {t} = useLocalize();

--- a/src/managers/GalleyManager/galleyManagerStore.js
+++ b/src/managers/GalleyManager/galleyManagerStore.js
@@ -85,6 +85,7 @@ export const useGalleyManagerStore = defineComponentStore(
 			galleyManagerConfig.getManagerConfig({
 				submission,
 				publication,
+				canCurrentUserEditPublication: props.canCurrentUserEditPublication,
 			}),
 		);
 
@@ -149,6 +150,17 @@ export const useGalleyManagerStore = defineComponentStore(
 			);
 		}
 
+		function galleyView({galley}) {
+			galleyManagerActions.galleyView(
+				{
+					galley,
+					publication: props.publication,
+					submission: props.submission,
+				},
+				triggerDataChangeCallback,
+			);
+		}
+
 		function galleyDelete({galley}) {
 			galleyManagerActions.galleyDelete(
 				{
@@ -192,6 +204,7 @@ export const useGalleyManagerStore = defineComponentStore(
 			/** Actions */
 			galleyAdd,
 			galleyEdit,
+			galleyView,
 			galleyChangeFile,
 			galleyDelete,
 			galleyMoreInfo,

--- a/src/managers/GalleyManager/galleyManagerStore.js
+++ b/src/managers/GalleyManager/galleyManagerStore.js
@@ -18,6 +18,8 @@ export const useGalleyManagerStore = defineComponentStore(
 
 		const {triggerDataChange} = useDataChanged();
 
+		const galleyManagerConfig = extender.addFns(useGalleyManagerConfig());
+
 		/**
 		 * Sorting with useOrdering composable
 		 */
@@ -33,7 +35,7 @@ export const useGalleyManagerStore = defineComponentStore(
 			onSave: async (orderedItems) => {
 				const {openDialogNetworkError} = useModal();
 				const {url} = useLegacyGridUrl({
-					component: 'grid.articleGalleys.ArticleGalleyGridHandler',
+					component: galleyManagerConfig.getGalleyGridComponent(),
 					op: 'saveSequence',
 					params: {
 						submissionId: props.submission.id,
@@ -75,7 +77,6 @@ export const useGalleyManagerStore = defineComponentStore(
 		/** Reload files when data on screen changes */
 
 		/** Columns */
-		const galleyManagerConfig = extender.addFns(useGalleyManagerConfig());
 		const columns = computed(() => galleyManagerConfig.getColumns());
 
 		/**

--- a/src/managers/GalleyManager/useGalleyManagerActions.js
+++ b/src/managers/GalleyManager/useGalleyManagerActions.js
@@ -6,6 +6,7 @@ export const Actions = {
 	GALLEY_LIST: 'galleyList',
 	GALLEY_ADD: 'galleyAdd',
 	GALLEY_EDIT: 'galleyEdit',
+	GALLEY_VIEW: 'galleyView',
 	GALLEY_CHANGE_FILE: 'galleyChangeFile',
 	GALLEY_DELETE: 'galleyDelete',
 	GALLEY_SORT: 'galleySort',
@@ -81,6 +82,23 @@ export function useGalleyManagerActions({galleyGridComponent}) {
 		openLegacyModal({title: t('submission.upload.proof')}, finishedCallback);
 	}
 
+	function galleyView({submission, publication, galley}, finishedCallback) {
+		const {openLegacyModal} = useLegacyGridUrl({
+			component: galleyGridComponent,
+			op: 'editGalley',
+			params: {
+				submissionId: submission.id,
+				publicationId: publication.id,
+				representationId: galley.id,
+			},
+		});
+
+		openLegacyModal(
+			{title: t('submission.layout.viewGalley')},
+			finishedCallback,
+		);
+	}
+
 	function galleyDelete({submission, publication, galley}, finishedCallback) {
 		const {openDialog, openDialogNetworkError} = useModal();
 		openDialog({
@@ -153,6 +171,7 @@ export function useGalleyManagerActions({galleyGridComponent}) {
 		galleyChangeFile,
 		galleyAdd,
 		galleyEdit,
+		galleyView,
 		galleyDelete,
 		galleyMoreInfo,
 	};

--- a/src/managers/GalleyManager/useGalleyManagerConfig.js
+++ b/src/managers/GalleyManager/useGalleyManagerConfig.js
@@ -3,40 +3,70 @@ import {useApp} from '@/composables/useApp';
 import {Actions} from './useGalleyManagerActions';
 import {useCurrentUser} from '@/composables/useCurrentUser';
 
-export const GalleyManagerConfiguration = {
-	permissions: [
-		{
-			roles: [pkp.const.ROLE_ID_AUTHOR],
-			actions: [Actions.GALLEY_LIST],
-		},
-		{
-			roles: [
-				pkp.const.ROLE_ID_SUB_EDITOR,
-				pkp.const.ROLE_ID_MANAGER,
-				pkp.const.ROLE_ID_SITE_ADMIN,
-				pkp.const.ROLE_ID_ASSISTANT,
-			],
-			actions: [
-				Actions.GALLEY_LIST,
-				Actions.GALLEY_ADD,
-				Actions.GALLEY_CHANGE_FILE,
-				Actions.GALLEY_DELETE,
-				Actions.GALLEY_EDIT,
-				Actions.GALLEY_SORT,
-				Actions.GALLEY_MORE_INFO,
-			],
-		},
-	],
-	actions: [
-		Actions.GALLEY_LIST,
-		Actions.GALLEY_ADD,
-		Actions.GALLEY_CHANGE_FILE,
-		Actions.GALLEY_DELETE,
-		Actions.GALLEY_EDIT,
-		Actions.GALLEY_SORT,
-		Actions.GALLEY_MORE_INFO,
-	],
-};
+function getAuthorActions(canCurrentUserEditPublication) {
+	const {isOPS} = useApp();
+
+	// In OJS/OMP, authors can only view the galley listing
+	if (!isOPS()) {
+		return [Actions.GALLEY_LIST];
+	}
+
+	// In OPS, authors manage their galleys themselves when they have the
+	// permission to edit the publication, mirroring the backend
+	// (PreprintGalleyGridHandler)
+	if (canCurrentUserEditPublication) {
+		return [
+			Actions.GALLEY_LIST,
+			Actions.GALLEY_ADD,
+			Actions.GALLEY_CHANGE_FILE,
+			Actions.GALLEY_DELETE,
+			Actions.GALLEY_EDIT,
+			Actions.GALLEY_SORT,
+		];
+	}
+
+	// Otherwise they get a read-only 'View' of the galley details,
+	// consistent with 3.3/3.4
+	return [Actions.GALLEY_LIST, Actions.GALLEY_VIEW];
+}
+
+export function getGalleyManagerConfiguration({canCurrentUserEditPublication}) {
+	return {
+		permissions: [
+			{
+				roles: [pkp.const.ROLE_ID_AUTHOR],
+				actions: getAuthorActions(canCurrentUserEditPublication),
+			},
+			{
+				roles: [
+					pkp.const.ROLE_ID_SUB_EDITOR,
+					pkp.const.ROLE_ID_MANAGER,
+					pkp.const.ROLE_ID_SITE_ADMIN,
+					pkp.const.ROLE_ID_ASSISTANT,
+				],
+				actions: [
+					Actions.GALLEY_LIST,
+					Actions.GALLEY_ADD,
+					Actions.GALLEY_CHANGE_FILE,
+					Actions.GALLEY_DELETE,
+					Actions.GALLEY_EDIT,
+					Actions.GALLEY_SORT,
+					Actions.GALLEY_MORE_INFO,
+				],
+			},
+		],
+		actions: [
+			Actions.GALLEY_LIST,
+			Actions.GALLEY_ADD,
+			Actions.GALLEY_CHANGE_FILE,
+			Actions.GALLEY_DELETE,
+			Actions.GALLEY_EDIT,
+			Actions.GALLEY_VIEW,
+			Actions.GALLEY_SORT,
+			Actions.GALLEY_MORE_INFO,
+		],
+	};
+}
 
 export function useGalleyManagerConfig() {
 	const {t} = useLocalize();
@@ -77,23 +107,27 @@ export function useGalleyManagerConfig() {
 		return columns;
 	}
 
-	function getManagerConfig({submission, publication}) {
-		const permittedActions = GalleyManagerConfiguration.actions
-			.filter((action) => {
-				return true;
-			})
-			.filter((action) => {
-				return GalleyManagerConfiguration.permissions.some((perm) => {
-					return (
-						perm.actions.includes(action) &&
-						hasCurrentUserAtLeastOneAssignedRoleInStage(
-							submission.value,
-							pkp.const.WORKFLOW_STAGE_ID_PRODUCTION,
-							perm.roles,
-						)
-					);
-				});
+	function getManagerConfig({
+		submission,
+		publication,
+		canCurrentUserEditPublication,
+	}) {
+		const configuration = getGalleyManagerConfiguration({
+			canCurrentUserEditPublication,
+		});
+
+		const permittedActions = configuration.actions.filter((action) => {
+			return configuration.permissions.some((perm) => {
+				return (
+					perm.actions.includes(action) &&
+					hasCurrentUserAtLeastOneAssignedRoleInStage(
+						submission.value,
+						pkp.const.WORKFLOW_STAGE_ID_PRODUCTION,
+						perm.roles,
+					)
+				);
 			});
+		});
 		return {permittedActions};
 	}
 
@@ -127,20 +161,16 @@ export function useGalleyManagerConfig() {
 		const actions = [];
 
 		if (config.permittedActions.includes(Actions.GALLEY_EDIT)) {
-			const label =
-				publication.status === pkp.const.publication.STATUS_PUBLISHED
-					? t('common.view')
-					: t('common.edit');
-
-			const icon =
-				publication.status === pkp.const.publication.STATUS_PUBLISHED
-					? 'View'
-					: 'Edit';
-
 			actions.push({
-				label,
+				label: t('common.edit'),
 				name: Actions.GALLEY_EDIT,
-				icon,
+				icon: 'Edit',
+			});
+		} else if (config.permittedActions.includes(Actions.GALLEY_VIEW)) {
+			actions.push({
+				label: t('common.view'),
+				name: Actions.GALLEY_VIEW,
+				icon: 'View',
 			});
 		}
 

--- a/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
+++ b/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
@@ -460,6 +460,7 @@ export const PublicationConfig = {
 					props: {
 						submission,
 						publication: selectedPublication,
+						canCurrentUserEditPublication: permissions.canEditPublication,
 					},
 				},
 			];

--- a/src/pages/workflow/composables/useWorkflowConfig/workflowConfigEditorialOJS.js
+++ b/src/pages/workflow/composables/useWorkflowConfig/workflowConfigEditorialOJS.js
@@ -1078,7 +1078,7 @@ export const PublicationConfig = {
 					props: {
 						submission,
 						publication: selectedPublication,
-						canEdit: permissions.canEditPublication,
+						canCurrentUserEditPublication: permissions.canEditPublication,
 					},
 				},
 			];


### PR DESCRIPTION
For pkp/pkp-lib#13039.

- Passes `canCurrentUserEditPublication` (`submission.canCurrentUserChangeMetadata`, incl. the author lock from pkp/pkp-lib#10263) to the `GalleyManager`.
- In OPS, authors can add/edit/change file/delete/order galleys when they have the permission to edit the publication — mirroring the backend (`PreprintGalleyGridHandler`), where these operations have always been whitelisted for authors. OJS/OMP authors are unaffected (their backend grid is read-only for authors).
- Introduces a read-only `GALLEY_VIEW` action (opens the galley details modal, served disabled by the backend), offered to OPS authors whenever the galleys are not editable — published, locked or permission revoked — consistent with 3.3/3.4.
- Drops the 'View' relabeling of the Edit action for published publications: obsolete since pkp/pkp-lib#10263 allows editorial roles to edit galleys of published publications (the warning banner communicates the published state).

The galley manager configuration was restructured into a parameterized factory (same pattern as `FileManagerConfigurations`), so the permission matrix stays declarative with a single row per role.