### PR TITLE
pkp/dev-team#314 [Peer Review Summary] | Reader Workflow - Article Landing Page, synchronize the language of the reviewer status

### DIFF
--- a/src/frontend/components/PkpOpenReview/PkpOpenReviewByReviewer.vue
+++ b/src/frontend/components/PkpOpenReview/PkpOpenReviewByReviewer.vue
@@ -56,7 +56,7 @@
 								</span>
 								<span :class="cn('reviewHeaderText')">
 									<span :class="cn('reviewStatusText')">
-										{{ review.reviewerRecommendationDisplayText }}
+										{{ review.reviewerRecommendationLabel }}
 									</span>
 									<span :class="cn('reviewHeaderMeta')">
 										<span :class="cn('version')">

--- a/src/frontend/components/PkpOpenReview/PkpOpenReviewByRound.vue
+++ b/src/frontend/components/PkpOpenReview/PkpOpenReviewByRound.vue
@@ -61,7 +61,7 @@
 								</span>
 								<span :class="cn('reviewHeaderText')">
 									<span :class="cn('reviewStatusText')">
-										{{ review.reviewerRecommendationDisplayText }}
+										{{ review.reviewerRecommendationLabel }}
 									</span>
 									<span :class="cn('reviewHeaderMeta')">
 										<span :class="cn('reviewer')">

--- a/src/frontend/components/PkpOpenReview/docs/PkpOpenReview.mdx
+++ b/src/frontend/components/PkpOpenReview/docs/PkpOpenReview.mdx
@@ -499,7 +499,7 @@ pkp.registry.registerComponent('PkpOpenReview', {
 			<template #reviewHeader="{ review }">
 				<div class="my-custom-review-header">
 					<strong>{{ review.reviewerFullName }}</strong>
-					<span>{{ review.reviewerRecommendationDisplayText }}</span>
+					<span>{{ review.reviewerRecommendationLabel }}</span>
 				</div>
 			</template>
 		</BaseOpenReview>

--- a/src/frontend/components/PkpOpenReview/docs/PkpOpenReview.stories.js
+++ b/src/frontend/components/PkpOpenReview/docs/PkpOpenReview.stories.js
@@ -88,7 +88,7 @@ export const CustomReviewItem = {
 						</div>
 						<span style="padding: 4px 8px; border-radius: 4px; font-size: 12px; flex-shrink: 0;"
 								:style="{ background: review.reviewerRecommendationTypeKey === 'approved' ? '#d1fae5' : '#fef3c7' }">
-							{{ review.reviewerRecommendationDisplayText }}
+							{{ review.reviewerRecommendationLabel }}
 						</span>
 					</div>
 				</template>
@@ -143,7 +143,7 @@ export const MinimalLayout = {
 				<template #reviewHeader="{ review }">
 					<span style="display: flex; align-items: center; gap: 12px; width: 100%;">
 						<span style="flex: 1;">{{ review.reviewerFullName }}</span>
-						<span style="color: #666; font-size: 13px;">{{ review.reviewerRecommendationDisplayText }}</span>
+						<span style="color: #666; font-size: 13px;">{{ review.reviewerRecommendationLabel }}</span>
 					</span>
 				</template>
 			</PkpOpenReview>

--- a/src/frontend/components/PkpOpenReview/usePkpOpenReviewStore.js
+++ b/src/frontend/components/PkpOpenReview/usePkpOpenReviewStore.js
@@ -163,6 +163,10 @@ export const usePkpOpenReviewStore = defineStore('pkpOpenReview', () => {
 								...review,
 								reviewerRecommendationTypeKey: typeInfo?.key || null,
 								reviewerRecommendationTypeIcon: typeInfo?.iconName || null,
+								// Match the summary counts; fall back to the journal's own wording.
+								reviewerRecommendationLabel:
+									review.reviewerRecommendationTypeLabel ||
+									review.reviewerRecommendationDisplayText,
 								round: roundInfo,
 							};
 						}),


### PR DESCRIPTION
The journal summary displayed in the Article tab is uses `reviewerRecommendationTypeLabel`. We need to match use the same status text in the Peer Review Record tab. 