### PR TITLE
Move author response tool higher in author workflow

### DIFF
--- a/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
+++ b/src/pages/workflow/composables/useWorkflowConfig/workflowConfigAuthorOJS.js
@@ -186,11 +186,6 @@ export const WorkflowConfig = {
 				},
 			});
 
-			items.push({
-				component: 'DiscussionManager',
-				props: {submission, submissionStageId: selectedStageId},
-			});
-
 			// Display the ReviewRoundResponseManager component if one of the following conditions is met:
 			// 1. An author response has been requested for the selected review round.
 			// 2. The review round has revisions requested.
@@ -211,6 +206,11 @@ export const WorkflowConfig = {
 					},
 				});
 			}
+
+			items.push({
+				component: 'DiscussionManager',
+				props: {submission, submissionStageId: selectedStageId},
+			});
 
 			return items;
 		},


### PR DESCRIPTION
From ORE UAT, a small enough change that I didn't bother with a ticket:

CERN would like the "author response" tool for authors to be moved higher in the UI.

> One more style thing, related to the Author Responses (it was on a ticket, but I can't find it right now): You moved the Request Author Response box on the editor side to under the Reviewers box (screen 1), but in the author view, this box is right at the bottom of the page still (screen 2). Can you move it up in the author pages too please to under Reviewers or Revisions uploaded? Many thanks :)  

I think this is a sensible change. @jardakotesovec, leaving up to you!