### PR TITLE
pkp/pkp-lib#13308 Citation processing progress counts over all citati…

### DIFF
--- a/public/globals.js
+++ b/public/globals.js
@@ -161,6 +161,7 @@ window.pkp = {
 		},
 
 		citationProcessingStatus: {
+			FAILED: -1,
 			NOT_PROCESSED: 0,
 			PID_EXTRACTED: 1,
 			CROSSREF: 2,

--- a/src/managers/CitationManager/CitationManagerCellCitation.vue
+++ b/src/managers/CitationManager/CitationManagerCellCitation.vue
@@ -158,6 +158,15 @@
 					</Badge>
 				</div>
 			</div>
+			<!-- lookup did not run to completion; can apply to either branch above -->
+			<div
+				v-if="citation.processingStatus == citationProcessingStatus.FAILED"
+				class="mt-2"
+			>
+				<Badge :color-variant="'attention'" :size-variant="'compact'">
+					{{ t('submission.citations.structured.lookupIncomplete') }}
+				</Badge>
+			</div>
 		</div>
 		<!-- citationsMetadataLookup disabled -->
 		<div v-else>

--- a/src/managers/CitationManager/CitationManagerStatusProcessed.vue
+++ b/src/managers/CitationManager/CitationManagerStatusProcessed.vue
@@ -2,31 +2,14 @@
 	<div v-if="total > 0">
 		<div class="flex items-center py-2">
 			<Icon
-				:icon="processed === total ? 'Complete' : 'InProgress'"
+				:icon="isFinished ? 'Complete' : 'InProgress'"
 				:class="'inline-block h-auto w-12 align-middle'"
 				:inline="true"
 			/>
 			<div class="align-middle">
-				<span class="font-semibold">
-					{{
-						processed === total
-							? t('submission.citations.structured.processed.title', {
-									total: total,
-								})
-							: t('submission.citations.structured.processing.title', {
-									processed: processed,
-									total: total,
-								})
-					}}
-				</span>
+				<span class="font-semibold">{{ statusTitle }}</span>
 				<br />
-				<p class="text-lg-normal">
-					{{
-						processed === total
-							? t('submission.citations.structured.processed.description')
-							: t('submission.citations.structured.processing.description')
-					}}
-				</p>
+				<p class="text-lg-normal">{{ statusDescription }}</p>
 			</div>
 		</div>
 	</div>
@@ -45,4 +28,41 @@ const citationStore = useCitationManagerStore();
 const total = computed(() => citationStore.totalCitations);
 
 const processed = computed(() => citationStore.processedCitations);
+
+const failed = computed(() => citationStore.failedCitations);
+
+const finished = computed(() => citationStore.finishedCitations);
+
+const isFinished = computed(() => finished.value === total.value);
+
+const statusTitle = computed(() => {
+	if (!isFinished.value) {
+		return t('submission.citations.structured.processing.title', {
+			processed: finished.value,
+			total: total.value,
+		});
+	}
+
+	if (failed.value > 0) {
+		return t('submission.citations.structured.processedWithFailures.title', {
+			processed: processed.value,
+			total: total.value,
+			failed: failed.value,
+		});
+	}
+
+	return t('submission.citations.structured.processed.title', {
+		total: total.value,
+	});
+});
+
+const statusDescription = computed(() => {
+	if (!isFinished.value) {
+		return t('submission.citations.structured.processing.description');
+	}
+
+	return failed.value > 0
+		? t('submission.citations.structured.processedWithFailures.description')
+		: t('submission.citations.structured.processed.description');
+});
 </script>

--- a/src/managers/CitationManager/citationManagerStore.js
+++ b/src/managers/CitationManager/citationManagerStore.js
@@ -63,13 +63,10 @@ export const useCitationManagerStore = defineComponentStore(
 		/**
 		 * status processed citations
 		 */
-		const structuredCitations = computed(() =>
-			(citations.value || []).filter((citation) => citation?.isStructured),
-		);
-		const totalCitations = computed(() => structuredCitations.value.length);
+		const totalCitations = computed(() => (citations.value || []).length);
 		const processedCitations = computed(
 			() =>
-				structuredCitations.value.filter(
+				(citations.value || []).filter(
 					(citation) =>
 						citation?.processingStatus ===
 						pkp.const.citationProcessingStatus.PROCESSED,

--- a/src/managers/CitationManager/citationManagerStore.js
+++ b/src/managers/CitationManager/citationManagerStore.js
@@ -63,14 +63,22 @@ export const useCitationManagerStore = defineComponentStore(
 		/**
 		 * status processed citations
 		 */
+		function countCitationsWithStatus(status) {
+			return (citations.value || []).filter(
+				(citation) => citation?.processingStatus === status,
+			).length;
+		}
+
 		const totalCitations = computed(() => (citations.value || []).length);
-		const processedCitations = computed(
-			() =>
-				(citations.value || []).filter(
-					(citation) =>
-						citation?.processingStatus ===
-						pkp.const.citationProcessingStatus.PROCESSED,
-				).length,
+		const processedCitations = computed(() =>
+			countCitationsWithStatus(pkp.const.citationProcessingStatus.PROCESSED),
+		);
+		const failedCitations = computed(() =>
+			countCitationsWithStatus(pkp.const.citationProcessingStatus.FAILED),
+		);
+		// A failed lookup has spent its retries, so it is as finished as a processed one.
+		const finishedCitations = computed(
+			() => processedCitations.value + failedCitations.value,
 		);
 
 		/**
@@ -79,7 +87,7 @@ export const useCitationManagerStore = defineComponentStore(
 		const reloadIntervalId = setInterval(() => {
 			if (
 				citationsMetadataLookup.value &&
-				processedCitations.value < totalCitations.value
+				finishedCitations.value < totalCitations.value
 			) {
 				// simple way to refresh publication
 				triggerDataChange();
@@ -277,6 +285,8 @@ export const useCitationManagerStore = defineComponentStore(
 
 			totalCitations,
 			processedCitations,
+			failedCitations,
+			finishedCitations,
 
 			deleteAllCitations,
 


### PR DESCRIPTION
…ons, instead of over only structured

see https://github.com/pkp/pkp-lib/issues/13308


The icon in the UI stays `Complete` when some lookups didn't finish, and the row badge reuses the neutral `attention` styling. @jardakotesovec, maybe we would like to change this too?